### PR TITLE
Added Google Analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,7 @@ module.exports = {
   siteMetadata: {
     title: "Frontside",
     description: "Build web applications at scale",
-    siteUrl: "https://frontside.io",
+    siteUrl: "https://frontside.io"
   },
   mapping: {
     "MarkdownRemark.fields.authors": "MarkdownRemark",
@@ -129,14 +129,20 @@ module.exports = {
       }
     },
     {
-      resolve: `gatsby-plugin-hotjar`,
+      resolve: "gatsby-plugin-hotjar",
       options: {
         id: 859026,
         sv: 6
       }
     },
     {
-      resolve: `gatsby-plugin-sitemap`,
+      resolve: "gatsby-plugin-google-analytics",
+      options: {
+        trackingId: "UA-44597640-1"
+      }
+    },
+    {
+      resolve: "gatsby-plugin-sitemap",
       options: {
         query: `
           {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "classnames": "^2.2.6",
     "gatsby": "^2.0.0",
     "gatsby-image": "^2.0.22",
+    "gatsby-plugin-google-analytics": "2.0.14",
     "gatsby-plugin-hotjar": "^1.0.1",
     "gatsby-plugin-netlify": "^2.0.0",
     "gatsby-plugin-netlify-cms": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6406,6 +6406,13 @@ gatsby-link@^2.0.11:
     "@types/reach__router" "^1.0.0"
     prop-types "^15.6.1"
 
+gatsby-plugin-google-analytics@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.0.14.tgz#b6f7e84f5eb6bcacd5831fe5dd8e8a3367136678"
+  integrity sha512-sFD73d9isJQknnDAAkDidaybHJx6VIaLfy3nO3DwbFaitvZ08RimbynYOkcWAeA0zwwix2RgAvbq/9pAmtTb/A==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 gatsby-plugin-hotjar@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-hotjar/-/gatsby-plugin-hotjar-1.0.1.tgz#f5703d7d2a354752e20230a0074d53c7287d8950"


### PR DESCRIPTION
## Purpose

We want to be able to track our new site in Google Analytics.

## Method

Installed `gatsby-plugin-google-analytics` plugin and added configuration.

## Learning

This plugin has a special link [component for creating links that track outbound](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#outboundlink-component) navigation. We'd probably want to use this to link to GitHub and Twitter.

<img width="733" alt="screen shot 2019-02-21 at 12 18 59 pm" src="https://user-images.githubusercontent.com/74687/53188218-e604f680-35d2-11e9-9c81-f80e9d0b292b.png">
