### PR TITLE
Make serif fonts the default

### DIFF
--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -5,6 +5,7 @@
   border-radius: var(--space-half);
   padding: var(--space-single) var(--space-double);
   margin-top: var(--space-triple);
+  font-family: var(--font-sans-serif);
   font-size: var(--size-small);
   text-align: center;
   text-transform: uppercase;

--- a/src/components/footer/footer.css
+++ b/src/components/footer/footer.css
@@ -47,6 +47,7 @@
   a {
     text-decoration: none;
     color: var(--link-color);
+    font-family: var(--font-sans-serif);
     font-size: var(--size-medium);
     font-weight: 600;
     line-height: 1;
@@ -56,6 +57,7 @@
 .footer-address {
   color: var(--body-color-faded);
   margin-bottom: var(--space-double-vw);
+  font-family: var(--font-sans-serif);
   font-size: var(--size-small);
   font-style: normal;
 

--- a/src/components/layout/layout.css
+++ b/src/components/layout/layout.css
@@ -3,7 +3,7 @@
 
 /* Default document styles */
 html {
-  font: 100%/1.8 var(--font-sans-serif);
+  font: 100%/1.8 var(--font-serif);
   background: var(--body-bg);
   color: var(--body-color);
 }
@@ -35,6 +35,7 @@ picture {
 /* Typography */
 h1, h2, h3 {
   line-height: 1.375;
+  font-family: var(--font-sans-serif);
   font-weight: 800;
   letter-spacing: 0.025em;
 }

--- a/src/components/navbar/navbar.css
+++ b/src/components/navbar/navbar.css
@@ -94,6 +94,7 @@ $navbar-height: calc($logo-height + ($navbar-padding * 2));
     text-decoration: none;
     color: var(--link-color);
     font-weight: 600;
+    font-family: var(--font-sans-serif);
     font-size: var(--size-med-lg);
 
     @media (--medium-up) {

--- a/src/components/testimonials/testimonials.css
+++ b/src/components/testimonials/testimonials.css
@@ -76,6 +76,7 @@
 
     cite {
       color: var(--body-color-faded);
+      font-family: var(--font-sans-serif);
       font-size: var(--size-med-sm);
       font-style: normal;
     }

--- a/src/components/text-field/text-field.css
+++ b/src/components/text-field/text-field.css
@@ -4,5 +4,6 @@
 
 .text-field-label {
   display: block;
+  font-family: var(--font-sans-serif);
   margin-bottom: var(--space-half);
 }


### PR DESCRIPTION
I noticed when working on https://github.com/thefrontside/frontside.io/pull/43 that lists in blog posts were coming through with a smaller sans, unlike the hearty serif body copy that surrounds it.

I switched the default to be the serif instead, since it makes more sense for the default to reflect body copy.