### PR TITLE
Increase size and margins for blog post lists

### DIFF
--- a/src/templates/blog-post.css
+++ b/src/templates/blog-post.css
@@ -5,6 +5,11 @@
 }
 
 .blog-post-content ul {
+  font-size: var(--size-base);
   margin-left: var(--space-double);
   margin-bottom: var(--space-one-half);
+}
+
+.blog-post-content li {
+  margin-bottom: var(--space-single);
 }


### PR DESCRIPTION
We received a "Text too small to read" alert for https://frontside.io/blog/2017-08-04-the-importance-of-build-health/ from the Google Search Console. I assume it was the smaller font sizes in `<ul>`s.

### Before
![frontside io_blog_2017-08-04-the-importance-of-build-health_(iPhone 5_SE)](https://user-images.githubusercontent.com/230597/54243065-f8e55980-44f4-11e9-908c-4165e6615af9.png)

### After
![localhost_8000_blog_2017-08-04-the-importance-of-build-health_(iPhone 5_SE)](https://user-images.githubusercontent.com/230597/54243069-fd117700-44f4-11e9-8f09-bb9cab491a19.png)
