### PR TITLE
Removed dots from lists on people pages

### DIFF
--- a/src/pages/people/index.js
+++ b/src/pages/people/index.js
@@ -23,7 +23,7 @@ const PeoplePage = ({
     <Layout>
       <Helmet title={`Team | ${title}`} />
       <h1>Team</h1>
-      <ul>
+      <ul className="list-style-none">
         {team.map(person => (
           <li key={person.frontmatter.name}>
             <Link to={person.fields.slug}>

--- a/src/templates/people.css
+++ b/src/templates/people.css
@@ -1,0 +1,3 @@
+.list-style-none {
+  list-style: none;
+}

--- a/src/templates/people.js
+++ b/src/templates/people.js
@@ -5,6 +5,7 @@ import Layout from "../components/layout";
 import Helmet from "react-helmet";
 import Img from "gatsby-image"
 import Content from "../components/content";
+import './people.css';
 
 const PersonPage = ({
   data: {
@@ -37,7 +38,7 @@ const PersonPage = ({
         <h1>{name}</h1>
         <div className="person-title">{personTitle}</div>
         <p>{bio}</p>
-        <ul>
+        <ul className="list-style-none">
           {twitter && (
             <li>Twitter: <a href={`https://twitter.com/${twitter}`}>{twitter}</a></li>
           )}
@@ -46,9 +47,9 @@ const PersonPage = ({
           )}
         </ul>
         {posts.length ? (
-          <div>
+          <>
             <h2>Blog Posts</h2>
-            <ul>
+            <ul className="list-style-none">
               {posts.map(post => (
                 <li key={post.fields.slug}>
                   <Link to={post.fields.slug}>
@@ -57,12 +58,12 @@ const PersonPage = ({
                 </li>
               ))}
             </ul>
-          </div>
+          </>
         ): null}
         {episodes.length ? (
-          <div>
+          <>
             <h2>Podcast Episodes</h2>
-            <ul>
+            <ul className="list-style-none">
               {episodes.map(episode => (
                 <li key={episode.number}>
                   <Link to={`/podcast/${episode.slug}`}>
@@ -71,7 +72,7 @@ const PersonPage = ({
                 </li>
               ))}
             </ul>
-          </div>
+          </>
         ) : null}
       </Content>
     </Layout>


### PR DESCRIPTION
## Motivation

Lists on people pages look bad because dots are showing up miss aligned. 

## Approach

Remove the lists styles with CSS

## Screenshots

### Before

<img width="1016" alt="Screen Shot 2019-06-03 at 8 47 43 AM" src="https://user-images.githubusercontent.com/74687/58802908-4b0db680-85dc-11e9-8b4e-de1ee4b0f5ec.png">

### After

<img width="1016" alt="Screen Shot 2019-06-03 at 8 47 32 AM" src="https://user-images.githubusercontent.com/74687/58802915-4fd26a80-85dc-11e9-842f-fa566337ee9e.png">
