### PR TITLE
Link services to contact page.

### DIFF
--- a/src/pages/services/index.js
+++ b/src/pages/services/index.js
@@ -46,7 +46,7 @@ export default function Services() {
             </p>
             <p className="service-thumb--cta">
               We’ll give you full visibility on what to look out for in every step of your project to ensure implementation goes smoothly.
-              <a href="/">Let’s build with confidence <FontAwesomeIcon icon={faArrowRight} /></a>
+              <a href="/contact">Let’s build with confidence <FontAwesomeIcon icon={faArrowRight} /></a>
             </p>
           </div>
         </div>
@@ -61,7 +61,7 @@ export default function Services() {
             </p>
             <p className="service-thumb--cta">
               You’ll get a comprehensive report on 12 key considerations along with practical steps to improve your platform’s architecture
-              <a href="/">Let’s plan ahead <FontAwesomeIcon icon={faArrowRight} /></a>
+              <a href="/contact">Let’s plan ahead <FontAwesomeIcon icon={faArrowRight} /></a>
             </p>
           </div>
         </div>
@@ -76,7 +76,7 @@ export default function Services() {
             </p>
             <p className="service-thumb--cta">
               By the end of our engagement, your team will be well equipped to continue building upon your platform for years to come.
-              <a href="/">Level up your team <FontAwesomeIcon icon={faArrowRight} /></a>
+              <a href="/contact">Level up your team <FontAwesomeIcon icon={faArrowRight} /></a>
             </p>
           </div>
         </div>
@@ -91,7 +91,7 @@ export default function Services() {
             </p>
             <p className="service-thumb--cta">
               Your team will learn how to make testing a normal and pain-free part of your company culture, write effective, long-lasting tests quickly and release code that’s resilient and on spec.
-              <a href="/">Let’s test together <FontAwesomeIcon icon={faArrowRight} /></a>
+              <a href="/contact">Let’s test together <FontAwesomeIcon icon={faArrowRight} /></a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
We want clients interested in our services to get in touch with us. That's why next to each service is listed a call to action. However, this call to action just links back to the homepage.

Instead, link to the contact form.

![2019-07-08 20 21 34](https://user-images.githubusercontent.com/4205/60829691-25b52f00-a1be-11e9-9408-9a0bc2044aba.gif)

