### PR TITLE
Change frontside's domain to .com

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,10 +4,9 @@ require('dotenv').config({
 
 module.exports = {
   siteMetadata: {
-    title: 'Frontside',
-    description:
-      'Austin-based frontend software engineering and architecture consultancy. We help teams build applications at scale.',
-    siteUrl: 'https://frontside.io',
+    title: "Frontside",
+    description: "Austin-based frontend software engineering and architecture consultancy. We help teams build applications at scale.",
+    siteUrl: "https://frontside.com"
   },
   mapping: {
     'MarkdownRemark.fields.authors': 'MarkdownRemark',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "platform-frontside",
   "description": "Frontend Platform for Frontside Website",
   "version": "2.0.0",
-  "author": "Taras <taras@frontside.io>",
+  "author": "Taras <taras@frontside.com>",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.17",

--- a/src/pages/blog/2016-01-22-functional-templating-in-ember.md
+++ b/src/pages/blog/2016-01-22-functional-templating-in-ember.md
@@ -139,7 +139,7 @@ The first time this technique really came together for me it felt impossibly lig
 
 I’m Charles Lowell ([@cowboyd][9] on twitter), and I build UI for a living at [The Frontside][10]. If you enjoyed this, I’d love to hear from you.
 
-Also, If you'd like to work with our team doing stuff like this, then please [get in touch](mailto:cowboyd@frontside.io). We're hiring.
+Also, If you'd like to work with our team doing stuff like this, then please [get in touch](mailto:cowboyd@frontside.com). We're hiring.
 
 
 
@@ -152,4 +152,4 @@ Also, If you'd like to work with our team doing stuff like this, then please [ge
 [7]: https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL
 [8]: http://posttestserver.com/
 [9]: https://twitter.com/cowboyd
-[10]: https://frontside.io
+[10]: https://frontside.com

--- a/src/pages/blog/2016-03-18-the-insider-track.md
+++ b/src/pages/blog/2016-03-18-the-insider-track.md
@@ -305,12 +305,12 @@ two.
 I’m Lydia Guarino ([@lydiaguarino][2] on twitter), and I build UI for a living at [The Frontside][3]. If you enjoyed this, I’d love to hear from you.
 
 If you have a project you'd like to work with us on,
-[get in touch](mailto:cowboyd@frontside.io). We're currently taking on
+[get in touch](mailto:cowboyd@frontside.com). We're currently taking on
 new projects.
 
 [1]: http://posttestserver.com/
 [2]: https://twitter.com/lydiaguarino
-[3]: https://frontside.io
+[3]: https://frontside.com
 [4]: http://www.harpersbazaar.com/culture/features/a10441/why-i-wear-the-same-thing-to-work-everday/
 [5]: http://www.inc.com/eric-v-holtzclaw/five-ways-to-use-social-media-at-conferences.html
 [6]: http://www.salestrainingadvice.com/2005/11/the-art-of-asking-good-questions-by-tim-hagen.html

--- a/src/pages/blog/2016-05-17-so-you-just-finished-a-bootcamp-now-what.md
+++ b/src/pages/blog/2016-05-17-so-you-just-finished-a-bootcamp-now-what.md
@@ -151,7 +151,7 @@ I’m Stephanie Riera ([@stefriera][2] on twitter), and I build web applications
 
 [1]: http://posttestserver.com/
 [2]: https://twitter.com/stefriera
-[3]: https://frontside.io
+[3]: https://frontside.com
 [4]: https://indeed.com
 [5]: https://upwork.com
 [6]: https://fiverr.com

--- a/src/pages/blog/2017-01-16-react-native-and-chill-a-tale-of-stupid-made-fast.md
+++ b/src/pages/blog/2017-01-16-react-native-and-chill-a-tale-of-stupid-made-fast.md
@@ -135,4 +135,4 @@ I’m Charles Lowell ([@cowboyd][5] on twitter), and I build UI for a living at 
 [3]: https://github.com/facebook/react-native/commit/c92ad5f6ae74c1d398c7cd93d5c4c50da0ca0430
 [4]: https://www.npmjs.com/package/react-native-chillest-monkey
 [5]: https://twitter.com/cowboyd
-[6]: http://frontside.io
+[6]: http://frontside.com

--- a/src/pages/blog/2017-06-01-one-helpful-way-to-think-about-javascript-decorators.md
+++ b/src/pages/blog/2017-06-01-one-helpful-way-to-think-about-javascript-decorators.md
@@ -340,6 +340,6 @@ For individual developers, decorators let us work with a lighter touch; applying
 <hr/>
 
 I’m Charles Lowell ([@cowboyd](https://twitter.com/cowboyd) on twitter), and I build UI for a
-living at [Frontside](http://frontside.io). If you enjoyed this, I’d love to hear
-from you. We're always [hiring](http://frontside.io/careers/) and
-looking for [exciting new work](http://frontside.io/services/)
+living at [Frontside](http://frontside.com). If you enjoyed this, I’d love to hear
+from you. We're always [hiring](http://frontside.com/careers/) and
+looking for [exciting new work](http://frontside.com/services/)

--- a/src/pages/blog/2017-06-21-building-a-ci-cd-deployment-solution-for-the-iot.md
+++ b/src/pages/blog/2017-06-21-building-a-ci-cd-deployment-solution-for-the-iot.md
@@ -231,4 +231,4 @@ This is what an image map of our setup would look like.
 
 Thanks for reading! I’m Elrick Ryan ([@elrickvm](https://twitter.com/elrickvm) on twitter), and I love building UI.
 
-If you're like us and always pushing the limits of awesome. We're the Frontside [drop us a line](http://frontside.io/contact/) and let's build it and ship it.
+If you're like us and always pushing the limits of awesome. We're the Frontside [drop us a line](http://frontside.com/contact/) and let's build it and ship it.

--- a/src/pages/blog/2017-12-22-frontside-forecast-the-growing-importance-of-blockchains.md
+++ b/src/pages/blog/2017-12-22-frontside-forecast-the-growing-importance-of-blockchains.md
@@ -41,7 +41,7 @@ Blockchain for Philanthropy. Charities would be able to provide a new level of t
 - **Blockchain for Identity Management:** A comprehensive identity platform that could protect against identity fraud and simplify legal proceedings where there are questions about identity.
 - **Blockchain for Film (Photo and Video):** Doctoring images would be much more difficult when photos belong to a chain.
 
-We’re excited about what the future holds for blockchain-backed applications, and we look forward to working on more blockchain projects in 2018. Please [get in touch with us](https://frontside.io/contact/) if you have an upcoming blockchain-backed project you’d like to collaborate on with us.
+We’re excited about what the future holds for blockchain-backed applications, and we look forward to working on more blockchain projects in 2018. Please [get in touch with us](https://frontside.com/contact/) if you have an upcoming blockchain-backed project you’d like to collaborate on with us.
 
 In future updates we’ll be defining what a blockchain software developer is and giving you an inside look into one of our current blockchain projects.
 

--- a/src/pages/blog/2017-12-29-quickly-build-component-libraries-with-storybook.md
+++ b/src/pages/blog/2017-12-29-quickly-build-component-libraries-with-storybook.md
@@ -97,4 +97,4 @@ Storybook is a big landmark for developing component libraries for the web, and 
 
 Check out this [Lunch and Learn](https://youtu.be/RHacQsTxnQ4) to see Storybook in action.
 
-Need help creating your own design system? [Reach out to Frontside.](https://frontside.io/contact/)
+Need help creating your own design system? [Reach out to Frontside.](https://frontside.com/contact/)

--- a/src/pages/blog/2018-02-19-math-is-just-another-framework.md
+++ b/src/pages/blog/2018-02-19-math-is-just-another-framework.md
@@ -206,12 +206,12 @@ to learn the math framework, the same feeling is waiting for you.
 I’m Charles Lowell, and I build UI for a living at [Frontside][6]. If
 you enjoyed this post, I’d love to hear from you. You can give me a
 shout on Twitter where I'm [@cowboyd][4], or drop me a line at
-[cowboyd@frontside.io][7]
+[cowboyd@frontside.com][7]
 
 [1]: http://127.0.0.1:59477/Dash/wbiryrnu/developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Array/map.html
 [2]: http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-map
 [3]: https://github.com/cowboyd/funcadelic.js
 [4]: https://twitter.com/cowboyd
 [5]: http://rubyonrails.org/doctrine/#convention-over-configuration
-[6]: https://frontside.io
-[7]: mailto:cowboyd@frontside.io
+[6]: https://frontside.com
+[7]: mailto:cowboyd@frontside.com

--- a/src/pages/blog/2018-06-14-what-is-new-in-wcag-2-1.md
+++ b/src/pages/blog/2018-06-14-what-is-new-in-wcag-2-1.md
@@ -254,4 +254,4 @@ Whew! That was a lot to unpack. One of the biggest struggles I had when getting 
 
 I think it is worthwhile for you to spend some time reading through a couple of the documents that explain the reasoning for these success criteria. One of the realizations I’ve had when reading through the spec is WCAG is a set of guidelines for improving your site’s UX. Accessibility really is all about making sure your site or app can be used by _anyone_, which serves as an excellent foundation to build upon for your site’s UX.
 
-If you or your team need any help getting up to speed with WCAG 2.1 [reach out to us!](https://frontside.io/contact) If you would like to ask any questions or continue this conversation feel free to [reach out to me on Twitter](https://twitter.com/robdel12).
+If you or your team need any help getting up to speed with WCAG 2.1 [reach out to us!](https://frontside.com/contact) If you would like to ask any questions or continue this conversation feel free to [reach out to me on Twitter](https://twitter.com/robdel12).

--- a/src/pages/blog/2018-07-03-functional-rephrasing-using-an-async-function-functor.md
+++ b/src/pages/blog/2018-07-03-functional-rephrasing-using-an-async-function-functor.md
@@ -183,7 +183,7 @@ it! But with the AsyncFunction Functor in your pocket, you've got options on you
 
 Photo by <a href="https://unsplash.com/photos/Opit9xvZDP0?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Jason Blackeye</a> on <a href="/?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Unsplash</a>
 
-[1]: https://frontside.io/img/2018/02/19/math-is-just-another-framework.html
+[1]: https://frontside.com/img/2018/02/19/math-is-just-another-framework.html
 [2]: https://github.com/cowboyd/funcadelic.js
 [3]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
 [4]: https://github.com/cowboyd/funcadelic.js#chaining-api

--- a/src/pages/blog/2018-08-09-kubernetes-for-the-kubernewbie.md
+++ b/src/pages/blog/2018-08-09-kubernetes-for-the-kubernewbie.md
@@ -283,7 +283,7 @@ your abilities, ask questions and don’t get discouraged when you can’t figur
 something out. There is still much to learn but that is nature of the Beast
 which we call technology. If you have any question you can always hit me on
 twitter at [@elrickvm](https://twitter.com/elrickvm) or [send an
-email](https://frontside.io/contact). Be blessed and happy coding!
+email](https://frontside.com/contact). Be blessed and happy coding!
 
 Photo by <a href="https://unsplash.com/photos/Q4bmoSPJM18">chuttersnap </a> on
 Unsplash.


### PR DESCRIPTION
## Motivation 

We are moving Frontside's website to `.com` instead of `.io`

## Approach

Change all the occurrences of `frontside.io` for `frontside.com`.

⚠️This PR should only be merged once records are changed on the domain and emails. 

## Immediately after merging this PR

- [x] Rename the repo to `frontside.com`
- [x] Change repo's description to `frontside.com`
- [x] Update [Twitter's profile link](https://twitter.com/thefrontside) to `frontside.com`
- [x] Update [LinkedIn profile link](https://www.linkedin.com/company/2439796/admin/?activeTab=buttons&edit=true). 
- [x] Change Org's URL and email: https://github.com/thefrontside (needs special org permissions)