### PR TITLE
Fixes Effection name

### DIFF
--- a/static/tools.html
+++ b/static/tools.html
@@ -124,7 +124,7 @@
   </section>
   <div class="tools-list-wrap">
     <div class="valuebox tool">
-      <h3 class="valuetitle"><span class="text-span-46">Affection</span>: algebraic effects API</h3>
+      <h3 class="valuetitle"><span class="text-span-46">Effection</span>: algebraic effects API</h3>
       <p>Over the years we’ve iterated on the ergonomics that make algebraic effects easy to use within popular javascript frameworks. This library makes it possible for us to have sophisticated concurrent threads running on BigTest. </p>
       <a href="https://github.com/thefrontside/effection" target="_blank" rel="nofollow" class="button topage small w-button">View on Github</a>
     </div>


### PR DESCRIPTION
The name of the library was incorrect on `tools.html` from webflow.