### PR TITLE
Sets all redirect codes to 302

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -14,10 +14,10 @@
 /about.html /about 302
 /people /about 302
 /consulting.html /consulting 302
-/services /consulting 307
-/tools.html /tools 307
-/contact.html /contact 307
-/contact-thanks.html /contact-thanks 307
+/services /consulting 302
+/tools.html /tools 302
+/contact.html /contact 302
+/contact-thanks.html /contact-thanks 302
 
 /about/:name  /people/:name 302
 


### PR DESCRIPTION
## Motivation

We received a warning from Google's search console stating that there was a misconfiguration on the redirect from `/services` to `/consulting`

## Approach

I figured that I had used another redirect code for some routes, that I thought was more suitable but turns out it was not. So I'm switching all redirects to use code 302 consistently.