### PR TITLE
chore: proxy /bigtest to bigtestjs website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,14 +7,8 @@
   YARN_FLAGS = "--no-ignore-optional"
 
 [[redirects]]
-  from = "/bigtest"
-  to = "https://bigtest.netlify.app/"
-  status = 200
-  force = true
-
-[[redirects]]
   from = "/bigtest/*"
-  to = "https://bigtest.netlify.app/:splat"
+  to = "https://bigtest.netlify.app/bigtest/:splat"
   status = 200
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,12 @@
   YARN_FLAGS = "--no-ignore-optional"
 
 [[redirects]]
+  from = "/bigtest/*"
+  to = "https://bigtest.netlify.app/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "https://frontside.io/*"
   to = "https://frontside.com/:splat"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,13 @@
   YARN_FLAGS = "--no-ignore-optional"
 
 [[redirects]]
-  from = "/bigtest*"
+  from = "/bigtest"
+  to = "https://bigtest.netlify.app/"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/bigtest/*"
   to = "https://bigtest.netlify.app/:splat"
   status = 200
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
   YARN_FLAGS = "--no-ignore-optional"
 
 [[redirects]]
-  from = "/bigtest/*"
+  from = "/bigtest*"
   to = "https://bigtest.netlify.app/:splat"
   status = 200
   force = true


### PR DESCRIPTION
The bigtest website is published separately from our main page. We want to rewrite the `/bigtest` urls to that separate publish location.