### PR TITLE
Adds the same http headers that bigtest uses for the iframe

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,3 +23,9 @@
   to = "https://frontside.com/:splat"
   status = 301
   force = true
+
+[[headers]]
+  for = "/bigtest/asciinema/iframes/cross-platform.html"
+
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"


### PR DESCRIPTION
## Motivation 

Even though we added the HTTP headers over BigTest netlify, the iframe still shows permissions problems.

## Approach

Given that the proxy to bigtest loads routes as if they were local, we must specify that that path is ok to load through an iframe in this host. I thus added that rule to the headers here.

[Seems to be working](https://deploy-preview-111--frontside.netlify.app/bigtest/platform)