### PR TITLE
Adds Code of Conduct and Privacy Policy to the site

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Tue Jan 05 2021 16:31:51 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Jan 08 2021 14:25:32 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5f8432592616248537dab3da" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -19,6 +19,7 @@
   <link href="css/webflow.css" rel="stylesheet" type="text/css">
   <link href="css/frontside-website.webflow.css" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="https://use.typekit.net/gyc5wys.css" />
+
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
@@ -236,6 +237,11 @@
     <a href="/" class="footer-symbol w-inline-block"><img src="images/fs-webclip.png" loading="lazy" width="32.5" alt="" class="image-6"></a>
     <p class="footer-notes"><br>2301 W Anderson Ln #107<br>Austin, Texas 78757<br>+1 (800) 493-4589</p>
     <p class="copyright">© 2005-2020 THE FRONTSIDE SOFTWARE, INC. ALL RIGHTS RESERVED.</p>
+    <div class="copyright w-richtext">
+      <p>
+        <a href="/code-of-conduct">Code of Conduct</a> | <a href="/privacy-policy">Privacy Policy </a>
+      </p>
+    </div>
   </footer>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5f7f19d60c33ef0c409a8bf8" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="js/webflow.js" type="text/javascript"></script>

--- a/static/code-of-conduct.html
+++ b/static/code-of-conduct.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
 <!--  Last Published: Fri Jan 08 2021 14:25:32 GMT+0000 (Coordinated Universal Time)  -->
-<html data-wf-page="5fb254240cbef141bb1db2c7" data-wf-site="5f7f19d60c33ef0c409a8bf8">
+<html data-wf-page="5ff8461070f91cfc9f86b97c" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
-  <title>Thanks</title>
-  <meta content="We&#x27;ll get back to you as soon as possible." name="description">
-  <meta content="Thanks" property="og:title">
-  <meta content="We&#x27;ll get back to you as soon as possible." property="og:description">
-  <meta content="Thanks" property="twitter:title">
-  <meta content="We&#x27;ll get back to you as soon as possible." property="twitter:description">
+  <title>Code of Conduct</title>
+  <meta content="In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience" name="description">
+  <meta content="Code of Conduct" property="og:title">
+  <meta content="In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience" property="og:description">
+  <meta content="Code of Conduct" property="twitter:title">
+  <meta content="In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience" property="twitter:description">
   <meta property="og:type" content="website">
   <meta content="summary_large_image" name="twitter:card">
   <meta content="width=device-width, initial-scale=1" name="viewport">
@@ -92,8 +92,59 @@
   </div>
   <div class="home-hero contact">
     <div class="herotext cenetered">
-      <h1 class="heading centered">Thanks!</h1>
-      <p class="subheader centered">We&#x27;ll get back to you<br>within one business day</p>
+      <h1 class="heading centered">Code of conduct</h1>
+      <p class="subheader centered">All participants of the Frontside Community are expected to abide by our Code of Conduct, both online and during in-person events that are hosted and/or associated with Frontside.</p>
+    </div>
+  </div>
+  <div class="w-container">
+    <div class="w-richtext">
+      <h2>Our Pledge</h2>
+      <p>We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.</p>
+      <p>We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.</p>
+      <h2>Our Standards</h2>
+      <p>Examples of behavior that contributes to a positive environment for our community include:</p>
+      <ul role="list">
+        <li>Demonstrating empathy and kindness toward other people</li>
+        <li>Being respectful of differing opinions, viewpoints, and experiences</li>
+        <li>Giving and gracefully accepting constructive feedback</li>
+        <li>Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience</li>
+        <li>Focusing on what is best not just for us as individuals, but for the overall community</li>
+      </ul>
+      <p>Examples of unacceptable behavior include:</p>
+      <ul role="list">
+        <li>The use of sexualized language or imagery, and sexual attention or advances of any kind</li>
+        <li>Trolling, insulting or derogatory comments, and personal or political attacks</li>
+        <li>Public or private harassment</li>
+        <li>Publishing others’ private information, such as a physical or email address, without their explicit permission</li>
+        <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
+      </ul>
+      <h2>Enforcement Responsibilities</h2>
+      <p>Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.</p>
+      <p>Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.</p>
+      <h2>Scope</h2>
+      <p>This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.</p>
+      <h2>Enforcement</h2>
+      <p>Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at<a href="mailto:conduct@frontside.com"> conduct@frontside.com</a>. All complaints will be reviewed and investigated promptly and fairly.</p>
+      <p>All community leaders are obligated to respect the privacy and security of the reporter of any incident.</p>
+      <h2>Enforcement Guidelines</h2>
+      <p>Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:</p>
+      <h3>1. Correction</h3>
+      <p><strong>Community Impact</strong>: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.</p>
+      <p><strong>Consequence</strong>: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.</p>
+      <h3>2. Warning</h3>
+      <p><strong>Community Impact</strong>: A violation through a single incident or series of actions.</p>
+      <p><strong>Consequence</strong>: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.</p>
+      <h3>3. Temporary Ban</h3>
+      <p><strong>Community Impact</strong>: A serious violation of community standards, including sustained inappropriate behavior.</p>
+      <p><strong>Consequence</strong>: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.</p>
+      <h3>4. Permanent Ban</h3>
+      <p><strong>Community Impact</strong>: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.</p>
+      <p><strong>Consequence</strong>: A permanent ban from any sort of public interaction within the community.</p>
+      <h2>Attribution</h2>
+      <p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org/"><strong>Contributor Covenant</strong></a>, version 2.0, available at <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct.html"><strong>https://www.contributor-covenant.org/version/2/0/code_of_conduct.html</strong></a>.</p>
+      <p>Community Impact Guidelines were inspired by <a href="https://github.com/mozilla/diversity"><strong>Mozilla’s code of conduct enforcement ladder</strong></a>.</p>
+      <p>For answers to common questions about this code of conduct, see the FAQ at <a href="https://www.contributor-covenant.org/faq"><strong>https://www.contributor-covenant.org/faq</strong></a>. Translations are available at <a href="https://www.contributor-covenant.org/translations"><strong>https://www.contributor-covenant.org/translations</strong></a>.</p>
+      <h2>‍</h2>
     </div>
   </div>
   <footer class="footerwrapper w-container">
@@ -111,7 +162,7 @@
     <p class="copyright">© 2005-2020 THE FRONTSIDE SOFTWARE, INC. ALL RIGHTS RESERVED.</p>
     <div class="copyright w-richtext">
       <p>
-        <a href="/code-of-conduct">Code of Conduct</a> | <a href="/privacy-policy">Privacy Policy </a>
+        <a href="/code-of-conduct" aria-current="page" class="w--current">Code of Conduct</a> | <a href="/privacy-policy">Privacy Policy </a>
       </p>
     </div>
   </footer>

--- a/static/consulting.html
+++ b/static/consulting.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Tue Jan 05 2021 16:31:51 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Jan 08 2021 14:25:32 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5f85a0bba25bf148ce79acb4" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -19,6 +19,7 @@
   <link href="css/webflow.css" rel="stylesheet" type="text/css">
   <link href="css/frontside-website.webflow.css" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="https://use.typekit.net/gyc5wys.css" />
+
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
@@ -165,6 +166,11 @@
     <a href="/" class="footer-symbol w-inline-block"><img src="images/fs-webclip.png" loading="lazy" width="32.5" alt="" class="image-6"></a>
     <p class="footer-notes"><br>2301 W Anderson Ln #107<br>Austin, Texas 78757<br>+1 (800) 493-4589</p>
     <p class="copyright">© 2005-2020 THE FRONTSIDE SOFTWARE, INC. ALL RIGHTS RESERVED.</p>
+    <div class="copyright w-richtext">
+      <p>
+        <a href="/code-of-conduct">Code of Conduct</a> | <a href="/privacy-policy">Privacy Policy </a>
+      </p>
+    </div>
   </footer>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5f7f19d60c33ef0c409a8bf8" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="js/webflow.js" type="text/javascript"></script>

--- a/static/contact.html
+++ b/static/contact.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Tue Jan 05 2021 16:31:51 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Jan 08 2021 14:25:32 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5faea4534d61150d591f8411" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -17,6 +17,7 @@
   <link href="css/webflow.css" rel="stylesheet" type="text/css">
   <link href="css/frontside-website.webflow.css" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="https://use.typekit.net/gyc5wys.css" />
+
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
@@ -134,6 +135,11 @@
     <a href="/" class="footer-symbol w-inline-block"><img src="images/fs-webclip.png" loading="lazy" width="32.5" alt="" class="image-6"></a>
     <p class="footer-notes"><br>2301 W Anderson Ln #107<br>Austin, Texas 78757<br>+1 (800) 493-4589</p>
     <p class="copyright">© 2005-2020 THE FRONTSIDE SOFTWARE, INC. ALL RIGHTS RESERVED.</p>
+    <div class="copyright w-richtext">
+      <p>
+        <a href="/code-of-conduct">Code of Conduct</a> | <a href="/privacy-policy">Privacy Policy </a>
+      </p>
+    </div>
   </footer>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5f7f19d60c33ef0c409a8bf8" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="js/webflow.js" type="text/javascript"></script>

--- a/static/css/frontside-website.webflow.css
+++ b/static/css/frontside-website.webflow.css
@@ -1,3 +1,8 @@
+a {
+  color: #14315d;
+  text-decoration: none;
+}
+
 .widewrapper {
   display: -webkit-box;
   display: -webkit-flex;
@@ -644,7 +649,7 @@
 }
 
 .copyright {
-  margin-top: 40px;
+  margin-top: 10px;
   color: #4f6586;
   font-size: 12px;
   font-weight: 300;
@@ -1588,6 +1593,10 @@
 
 .centeredcontainer {
   text-align: center;
+}
+
+.link-2 {
+  text-decoration: none;
 }
 
 @media screen and (max-width: 991px) {

--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Tue Jan 05 2021 16:31:51 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Jan 08 2021 14:25:32 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5f7f19d60c33effa4a9a8bf9" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -19,6 +19,7 @@
   <link href="css/webflow.css" rel="stylesheet" type="text/css">
   <link href="css/frontside-website.webflow.css" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="https://use.typekit.net/gyc5wys.css" />
+
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
@@ -177,6 +178,11 @@
     <a href="/" aria-current="page" class="footer-symbol w-inline-block w--current"><img src="images/fs-webclip.png" loading="lazy" width="32.5" alt="" class="image-6"></a>
     <p class="footer-notes"><br>2301 W Anderson Ln #107<br>Austin, Texas 78757<br>+1 (800) 493-4589</p>
     <p class="copyright">© 2005-2020 THE FRONTSIDE SOFTWARE, INC. ALL RIGHTS RESERVED.</p>
+    <div class="copyright w-richtext">
+      <p>
+        <a href="/code-of-conduct">Code of Conduct</a> | <a href="/privacy-policy">Privacy Policy </a>
+      </p>
+    </div>
   </footer>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5f7f19d60c33ef0c409a8bf8" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="js/webflow.js" type="text/javascript"></script>

--- a/static/privacy-policy.html
+++ b/static/privacy-policy.html
@@ -107,13 +107,13 @@
       <p>‍</p>
       <h2><strong>1. WHAT INFORMATION DO WE COLLECT?</strong></h2>
       <h3><strong>Personal information you disclose to us<em>‍</em></strong></h3>
-      <p><em>In Short:  We collect personal information that you provide to us.</em>‍</p>
+      <p><em>We collect personal information that you provide to us.</em>‍</p>
       <p>We collect personal information that you voluntarily provide to us when you express an interest in obtaining information about us or our products and Services, when you participate in activities on the Website (such as by posting messages in our online forums or entering competitions, contests or giveaways) or otherwise when you contact us.</p>
       <p>The personal information that we collect depends on the context of your interactions with us and the Website, the choices you make and the products and features you use. The personal information we collect may include the following:<strong>‍</strong></p>
       <p><strong>Personal Information Provided by You.</strong> We collect names; email addresses; job titles; phone numbers; billing addresses; debit/credit card numbers; and other similar information.</p>
       <p>All personal information that you provide to us must be true, complete and accurate, and you must notify us of any changes to such personal information.<strong>‍</strong></p>
       <h3><strong>Information automatically collected<em>‍</em></strong></h3>
-      <p><em>In Short:  Some information such as your Internet Protocol (IP) address and/or browser and device characteristics is collected automatically when you visit our Website.</em>‍</p>
+      <p><em>Some information such as your Internet Protocol (IP) address and/or browser and device characteristics is collected automatically when you visit our Website.</em>‍</p>
       <p>We automatically collect certain information when you visit, use or navigate the Website. This information does not reveal your specific identity (like your name or contact information) but may include device and usage information, such as your IP address, browser and device characteristics, operating system, language preferences, referring URLs, device name, country, location, information about how and when you use our Website and other technical information. This information is primarily needed to maintain the security and operation of our Website, and for our internal analytics and reporting purposes.</p>
       <p>Like many businesses, we also collect information through cookies and similar technologies.</p>
       <p>The information we collect includes:</p>
@@ -124,7 +124,7 @@
       </ul>
       <p>‍</p>
       <h2>‍<strong>2. HOW DO WE USE YOUR INFORMATION?<em>‍</em></strong></h2>
-      <p><em>In Short:  We process your information for purposes based on legitimate business interests, the fulfillment of our contract with you, compliance with our legal obligations, and/or your consent.</em></p>
+      <p><em>We process your information for purposes based on legitimate business interests, the fulfillment of our contract with you, compliance with our legal obligations, and/or your consent.</em></p>
       <p>We use personal information collected via our Website for a variety of business purposes described below. We process your personal information for these purposes in reliance on our legitimate business interests, in order to enter into or perform a contract with you, with your consent, and/or for compliance with our legal obligations. We indicate the specific processing grounds we rely on next to each purpose listed below.</p>
       <p>We use the information we collect or receive:</p>
       <ul role="list">
@@ -137,7 +137,7 @@
       </ul>
       <p><br></p>
       <h2><strong>3. WILL YOUR INFORMATION BE SHARED WITH ANYONE?</strong></h2>
-      <p><em>In Short:  We only share information with your consent, to comply with laws, to provide you with services, to protect your rights, or to fulfill business obligations.</em></p>
+      <p><em>We only share information with your consent, to comply with laws, to provide you with services, to protect your rights, or to fulfill business obligations.</em></p>
       <p>We may process or share your data that we hold based on the following legal basis:</p>
       <ul role="list">
         <li><strong>Consent:</strong> We may process your data if you have given us specific consent to use your personal information for a specific purpose.</li>
@@ -152,24 +152,24 @@
       </ul>
       <p>‍</p>
       <h2><strong>4. DO WE USE COOKIES AND OTHER TRACKING TECHNOLOGIES?</strong></h2>
-      <p><em>In Short:  We may use cookies and other tracking technologies to collect and store your information.</em></p>
+      <p><em>We may use cookies and other tracking technologies to collect and store your information.</em></p>
       <p>We may use cookies and similar tracking technologies (like web beacons and pixels) to access or store information. Specific information about how we use such technologies and how you can refuse certain cookies is set out in our Cookie Notice.</p>
       <p><br></p>
       <h2><strong>5. HOW LONG DO WE KEEP YOUR INFORMATION?</strong></h2>
-      <p><em>In Short:  We keep your information for as long as necessary to fulfill the purposes outlined in this privacy notice unless otherwise required by law.</em></p>
+      <p><em>We keep your information for as long as necessary to fulfill the purposes outlined in this privacy notice unless otherwise required by law.</em></p>
       <p>We will only keep your personal information for as long as it is necessary for the purposes set out in this privacy notice, unless a longer retention period is required or permitted by law (such as tax, accounting or other legal requirements). No purpose in this notice will require us keeping your personal information for longer than 1 year.</p>
       <p>When we have no ongoing legitimate business need to process your personal information, we will either delete or anonymize such information, or, if this is not possible (for example, because your personal information has been stored in backup archives), then we will securely store your personal information and isolate it from any further processing until deletion is possible.</p>
       <p><br></p>
       <h2><strong>6. HOW DO WE KEEP YOUR INFORMATION SAFE?</strong></h2>
-      <p><em>In Short:  We aim to protect your personal information through a system of organizational and technical security measures.</em></p>
+      <p><em>We aim to protect your personal information through a system of organizational and technical security measures.</em></p>
       <p>We have implemented appropriate technical and organizational security measures designed to protect the security of any personal information we process. However, despite our safeguards and efforts to secure your information, no electronic transmission over the Internet or information storage technology can be guaranteed to be 100% secure, so we cannot promise or guarantee that hackers, cybercriminals, or other unauthorized third parties will not be able to defeat our security, and improperly collect, access, steal, or modify your information. Although we will do our best to protect your personal information, transmission of personal information to and from our Website is at your own risk. You should only access the Website within a secure environment.</p>
       <p><br></p>
       <h2><strong>7. DO WE COLLECT INFORMATION FROM MINORS?</strong></h2>
-      <p><em>In Short:  We do not knowingly collect data from or market to children under 18 years of age.</em></p>
+      <p><em>We do not knowingly collect data from or market to children under 18 years of age.</em></p>
       <p>We do not knowingly solicit data from or market to children under 18 years of age. By using the Website, you represent that you are at least 18 or that you are the parent or guardian of such a minor and consent to such minor dependentâ€™s use of the Website. If we learn that personal information from users less than 18 years of age has been collected, we will deactivate the account and take reasonable measures to promptly delete such data from our records. If you become aware of any data we may have collected from children under age 18, please contact us at privacy@frontside.com.</p>
       <p><br></p>
       <h2><strong>8. WHAT ARE YOUR PRIVACY RIGHTS?</strong></h2>
-      <p><em>In Short:  You may review, change, or terminate your account at any time.</em></p>
+      <p><em>You may review, change, or terminate your account at any time.</em></p>
       <p>If you are a resident in the European Economic Area and you believe we are unlawfully processing your personal information, you also have the right to complain to your local data protection supervisory authority. You can find their contact details here: <a href="http://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm">http://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm</a>.</p>
       <p>If you are a resident in Switzerland, the contact details for the data protection authorities are available here: <a href="https://www.edoeb.admin.ch/edoeb/en/home.html">https://www.edoeb.admin.ch/edoeb/en/home.html</a>.<br></p>
       <p><strong>Cookies and similar technologies:</strong> Most Web browsers are set to accept cookies by default. If you prefer, you can usually choose to set your browser to remove cookies and to reject cookies. If you choose to remove cookies or reject cookies, this could affect certain features or services of our Website. To opt-out of interest-based advertising by advertisers on our Website visit <a href="http://www.aboutads.info/choices/">http://www.aboutads.info/choices/</a>.</p>
@@ -178,7 +178,7 @@
       <p>Most web browsers and some mobile operating systems and mobile applications include a Do-Not-Track (&quot;DNT&quot;) feature or setting you can activate to signal your privacy preference not to have data about your online browsing activities monitored and collected. At this stage no uniform technology standard for recognizing and implementing DNT signals has been finalized. As such, we do not currently respond to DNT browser signals or any other mechanism that automatically communicates your choice not to be tracked online. If a standard for online tracking is adopted that we must follow in the future, we will inform you about that practice in a revised version of this privacy notice. </p>
       <p>‍</p>
       <h2>‍<strong>10. DO CALIFORNIA RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?</strong></h2>
-      <p><em>In Short:  Yes, if you are a resident of California, you are granted specific rights regarding access to your personal information.</em></p>
+      <p><em>Yes, if you are a resident of California, you are granted specific rights regarding access to your personal information.</em></p>
       <p>California Civil Code Section 1798.83, also known as the &quot;Shine The Light&quot; law, permits our users who are California residents to request and obtain from us, once a year and free of charge, information about categories of personal information (if any) we disclosed to third parties for direct marketing purposes and the names and addresses of all third parties with which we shared personal information in the immediately preceding calendar year. If you are a California resident and would like to make such a request, please submit your request in writing to us using the contact information provided below.</p>
       <p>If you are under 18 years of age, reside in California, and have a registered account with the Website, you have the right to request removal of unwanted data that you publicly post on the Website. To request removal of such data, please contact us using the contact information provided below, and include the email address associated with your account and a statement that you reside in California. We will make sure the data is not publicly displayed on the Website, but please be aware that the data may not be completely or comprehensively removed from all our systems (e.g. backups, etc.).</p>
       <p><br></p>
@@ -238,7 +238,7 @@
       <p>To exercise these rights, you can contact us by email at privacy@frontside.com, or by referring to the contact details at the bottom of this document. If you have a complaint about how we handle your data, we would like to hear from you.</p>
       <p>‍<br></p>
       <h2><strong>11. DO WE MAKE UPDATES TO THIS NOTICE?</strong></h2>
-      <p><em>In Short:  Yes, we will update this notice as necessary to stay compliant with relevant laws.</em></p>
+      <p><em>Yes, we will update this notice as necessary to stay compliant with relevant laws.</em></p>
       <p>We may update this privacy notice from time to time. The updated version will be indicated by an updated &quot;Revised&quot; date and the updated version will be effective as soon as it is accessible. If we make material changes to this privacy notice, we may notify you either by prominently posting a notice of such changes or by directly sending you a notification. We encourage you to review this privacy notice frequently to be informed of how we are protecting your information.</p>
       <p>‍<br></p>
       <h2><strong>12. HOW CAN YOU CONTACT US ABOUT THIS NOTICE?</strong></h2>

--- a/static/privacy-policy.html
+++ b/static/privacy-policy.html
@@ -141,7 +141,6 @@
       <p>We may process or share your data that we hold based on the following legal basis:</p>
       <ul role="list">
         <li><strong>Consent:</strong> We may process your data if you have given us specific consent to use your personal information for a specific purpose.</li>
-        <li><strong>Legitimate Interests:</strong> We may process your data when it is reasonably necessary to achieve our legitimate business interests.</li>
         <li><strong>Performance of a Contract:</strong> Where we have entered into a contract with you, we may process your personal information to fulfill the terms of our contract.</li>
         <li><strong>Legal Obligations:</strong> We may disclose your information where we are legally required to do so in order to comply with applicable law, governmental requests, a judicial proceeding, court order, or legal process, such as in response to a court order or a subpoena (including in response to public authorities to meet national security or law enforcement requirements).</li>
         <li><strong>Vital Interests:</strong> We may disclose your information where we believe it is necessary to investigate, prevent, or take action regarding potential violations of our policies, suspected fraud, situations involving potential threats to the safety of any person and illegal activities, or as evidence in litigation in which we are involved.</li>

--- a/static/privacy-policy.html
+++ b/static/privacy-policy.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
+<!--  Last Published: Fri Jan 08 2021 14:25:32 GMT+0000 (Coordinated Universal Time)  -->
+<html data-wf-page="5ff84eff8803020662abea89" data-wf-site="5f7f19d60c33ef0c409a8bf8">
+<head>
+  <meta charset="utf-8">
+  <title>Privacy Policy</title>
+  <meta content="We are committed to protecting your personal information and your right to privacy. If you have any questions or concerns about this privacy notice, or our practices with regards to your personal information, please contact us at privacy@frontside.com" name="description">
+  <meta content="Privacy Policy" property="og:title">
+  <meta content="We are committed to protecting your personal information and your right to privacy. If you have any questions or concerns about this privacy notice, or our practices with regards to your personal information, please contact us at privacy@frontside.com" property="og:description">
+  <meta content="Privacy Policy" property="twitter:title">
+  <meta content="We are committed to protecting your personal information and your right to privacy. If you have any questions or concerns about this privacy notice, or our practices with regards to your personal information, please contact us at privacy@frontside.com" property="twitter:description">
+  <meta property="og:type" content="website">
+  <meta content="summary_large_image" name="twitter:card">
+  <meta content="width=device-width, initial-scale=1" name="viewport">
+  <meta content="Webflow" name="generator">
+  <link href="css/normalize.css" rel="stylesheet" type="text/css">
+  <link href="css/webflow.css" rel="stylesheet" type="text/css">
+  <link href="css/frontside-website.webflow.css" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="https://use.typekit.net/gyc5wys.css" />
+
+  <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
+  <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
+  <link href="images/webclip.png" rel="apple-touch-icon">
+  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-44597640-1"></script>
+  <script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-44597640-1', {'anonymize_ip': false});</script><!--  Hotjar Tracking Code for https://frontside.com/  -->
+  <script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:859026,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+</head>
+<body class="fs-body">
+  <div data-collapse="medium" data-animation="over-right" data-duration="200" data-doc-height="1" data-easing="ease-in-out-circ" data-no-scroll="1" role="banner" class="navbar w-nav">
+    <div class="widewrapper w-container">
+      <a href="/" class="w-nav-brand">
+        <div class="w-embed"><svg width="137" height="34" xmlns="http://www.w3.org/2000/svg" alt="Frontside">
+            <g fill="none" fillrule="evenodd">
+              <path fill="#14315D" d="M15.2.04L.48 8.55v16.9l14.7 8.52 14.7-8.52V8.55z"></path>
+              <path fill="#F74D7B" d="M7.84 21.23v-8.45l-3.64-2.1v12.64l11 6.37v-4.2z"></path>
+              <path fill="#26ABE8" d="M22.54 21.23v-8.45l3.65-2.1v12.64l-11 6.37v-4.2z"></path>
+              <path fill="#FFF" d="M22.54 12.78l3.65-2.1-11-6.36-11 6.36 3.65 2.1 2.71-1.57 7.35 4.26 3.64-2.1-7.36-4.26 1.01-.59z"></path>
+              <g>
+                <path fill="#14315D" d="M38.58 11.51v11.7h2.88V18.8h4.37v-2.34h-4.37v-2.4h4.98V11.5zM51.7 13.98v3.03h1.47c1.17 0 1.77-.56 1.77-1.57 0-1-.55-1.46-1.7-1.46H51.7zm1.7-2.47c2.94 0 4.46 1.51 4.46 3.8 0 1.52-.6 2.56-1.78 3.24l2.42 4.67h-3.12l-1.97-4c-.3.04-.58.06-.91.06h-.8v3.94h-2.87v-11.7h4.56zM65.93 20.83c1.82 0 2.77-1.37 2.77-3.48 0-1.99-.95-3.42-2.77-3.42-1.8 0-2.74 1.45-2.74 3.42 0 2.1.94 3.48 2.74 3.48m0-9.51c3.56 0 5.79 2.34 5.79 6.03 0 3.8-2.23 6.08-5.79 6.08-3.54 0-5.77-2.28-5.77-6.08 0-3.7 2.23-6.03 5.77-6.03M74.34 11.51h2.5l4.54 6.88V11.5h2.85v11.7h-2.49l-4.57-6.72v6.73h-2.83zM89.79 14.05H86.4V11.5h9.64v2.54h-3.38v9.17h-2.88zM99.05 19.62c1.07.85 2.32 1.43 3.34 1.43.9 0 1.42-.42 1.42-1.12 0-.68-.4-.99-2.28-1.53-2.37-.68-3.4-1.62-3.4-3.5 0-2.46 1.9-3.58 4.3-3.58 1.54 0 3.04.56 4.2 1.62l-1.3 1.76a4.86 4.86 0 0 0-2.84-1.08c-.84 0-1.4.33-1.4.98 0 .76.67.97 2.6 1.6 2.17.7 3.11 1.55 3.11 3.42 0 2.4-1.69 3.8-4.37 3.8a6.34 6.34 0 0 1-4.78-2.04l1.4-1.76zM109.4 11.51h2.88v11.7h-2.88zM118.21 14.05v6.65h1.37c1.95 0 2.84-1.11 2.84-3.34 0-2.16-.9-3.31-2.84-3.31h-1.37zm1.37-2.54c3.9 0 5.85 2.3 5.85 5.66 0 4.2-2.03 6.05-6.3 6.05h-3.8v-11.7h4.25zM128.08 11.51h8.11v2.54h-5.23v2.1h4.74v2.37h-4.74v2.18h5.3v2.52h-8.18z"></path>
+              </g>
+            </g>
+          </svg></div>
+      </a>
+      <nav role="navigation" class="fullnav w-nav-menu">
+        <ul role="list" class="navwrap w-list-unstyled">
+          <li class="clase-nav">
+            <div class="menu-button-2 w-nav-button">
+              <div class="image-5 w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="33" height="17.5" viewbox="0 0 32.63 17" classname="image-4">
+                  <path fill="#14315d" d="M7.4,0,0,4.27v8.46L7.4,17l7.34-4.27V4.27ZM7.34,2.82l5,2.89v5.64L7.4,14.18,2.45,11.35V5.71L4.2,4.64"></path>
+                  <path fill="#14315d" d="M25.29,0,17.88,4.27v8.46L25.29,17l7.34-4.27V4.27Zm-.07,2.82,5,2.89v5.64l-4.89,2.83-5-2.83V5.71l1.76-1.07"></path>
+                </svg></div>
+            </div>
+          </li>
+          <li class="navitem homelink">
+            <a href="/" class="main-nav-link w-nav-link">Homepage</a>
+          </li>
+          <li class="navitem">
+            <a href="/about" class="main-nav-link w-nav-link">People</a>
+          </li>
+          <li class="navitem">
+            <a href="/consulting" class="main-nav-link w-nav-link">Consulting</a>
+          </li>
+          <li class="navitem">
+            <a href="/tools" class="main-nav-link w-nav-link">Tools</a>
+          </li>
+          <li class="navitem">
+            <a href="/blog" class="main-nav-link w-nav-link">Blog</a>
+          </li>
+          <li class="navitem contactin">
+            <a href="/contact" class="button cta nav in w-button">Contact</a>
+          </li>
+        </ul>
+      </nav>
+      <a href="/contact" class="button cta nav w-button">Contact</a>
+      <div class="menu-button-2 w-nav-button">
+        <div class="image-4 w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="33" height="17.5" viewbox="0 0 32.63 17" classname="image-4">
+            <path fill="#14315d" d="M7.4,0,0,4.27v8.46L7.4,17l7.34-4.27V4.27ZM7.34,2.82l5,2.89v5.64L7.4,14.18,2.45,11.35V5.71L4.2,4.64"></path>
+            <path fill="#14315d" d="M25.29,0,17.88,4.27v8.46L25.29,17l7.34-4.27V4.27Zm-.07,2.82,5,2.89v5.64l-4.89,2.83-5-2.83V5.71l1.76-1.07"></path>
+          </svg></div>
+      </div>
+    </div>
+  </div>
+  <div class="home-hero contact">
+    <div class="herotext cenetered">
+      <h1 class="heading centered">Privacy policy</h1>
+      <p class="subheader centered">We are committed to protecting your personal information and your right to privacy. Please contact us at privacy@frontside.com for any related query.</p>
+    </div>
+  </div>
+  <div class="w-container">
+    <div class="w-richtext">
+      <p><strong>Last updated January 08, 2021</strong></p>
+      <p><br></p>
+      <p>Thank you for choosing to be part of our community at The Frontside Software, Inc, doing business as Frontside (&quot;<strong>Frontside</strong>&quot;, &quot;<strong>we</strong>&quot;, &quot;<strong>us</strong>&quot;, &quot;<strong>our</strong>&quot;). We are committed to protecting your personal information and your right to privacy. If you have any questions or concerns about this privacy notice, or our practices with regards to your personal information, please contact us at legal@frontside.com.</p>
+      <p>When you visit our website <a href="https://frontside.com/">https://frontside.com/</a> (the &quot;<strong>Website</strong>&quot;), and more generally, use any of our services (the &quot;<strong>Services</strong>&quot;, which include the Website), we appreciate that you are trusting us with your personal information. We take your privacy very seriously. In this privacy notice, we seek to explain to you in the clearest way possible what information we collect, how we use it and what rights you have in relation to it. We hope you take some time to read through it carefully, as it is important. If there are any terms in this privacy notice that you do not agree with, please discontinue use of our Services immediately.</p>
+      <p>This privacy notice applies to all information collected through our Services (which, as described above, includes our Website), as well as, any related services, sales, marketing or events.</p>
+      <p><strong>Please read this privacy notice carefully as it will help you understand what we do with the information that we collect.</strong></p>
+      <p>‍</p>
+      <h2><strong>1. WHAT INFORMATION DO WE COLLECT?</strong></h2>
+      <h3><strong>Personal information you disclose to us<em>‍</em></strong></h3>
+      <p><em>In Short:  We collect personal information that you provide to us.</em>‍</p>
+      <p>We collect personal information that you voluntarily provide to us when you express an interest in obtaining information about us or our products and Services, when you participate in activities on the Website (such as by posting messages in our online forums or entering competitions, contests or giveaways) or otherwise when you contact us.</p>
+      <p>The personal information that we collect depends on the context of your interactions with us and the Website, the choices you make and the products and features you use. The personal information we collect may include the following:<strong>‍</strong></p>
+      <p><strong>Personal Information Provided by You.</strong> We collect names; email addresses; job titles; phone numbers; billing addresses; debit/credit card numbers; and other similar information.</p>
+      <p>All personal information that you provide to us must be true, complete and accurate, and you must notify us of any changes to such personal information.<strong>‍</strong></p>
+      <h3><strong>Information automatically collected<em>‍</em></strong></h3>
+      <p><em>In Short:  Some information such as your Internet Protocol (IP) address and/or browser and device characteristics is collected automatically when you visit our Website.</em>‍</p>
+      <p>We automatically collect certain information when you visit, use or navigate the Website. This information does not reveal your specific identity (like your name or contact information) but may include device and usage information, such as your IP address, browser and device characteristics, operating system, language preferences, referring URLs, device name, country, location, information about how and when you use our Website and other technical information. This information is primarily needed to maintain the security and operation of our Website, and for our internal analytics and reporting purposes.</p>
+      <p>Like many businesses, we also collect information through cookies and similar technologies.</p>
+      <p>The information we collect includes:</p>
+      <ul role="list">
+        <li><em>Log and Usage Data.</em> Log and usage data is service-related, diagnostic, usage and performance information our servers automatically collect when you access or use our Website and which we record in log files. Depending on how you interact with us, this log data may include your IP address, device information, browser type and settings and information about your activity in the Website (such as the date/time stamps associated with your usage, pages and files viewed, searches and other actions you take such as which features you use), device event information (such as system activity, error reports (sometimes called &#x27;crash dumps&#x27;) and hardware settings).</li>
+        <li><em>Device Data.</em> We collect device data such as information about your computer, phone, tablet or other device you use to access the Website. Depending on the device used, this device data may include information such as your IP address (or proxy server), device and application identification numbers, location, browser type, hardware model Internet service provider and/or mobile carrier, operating system and system configuration information.</li>
+        <li><em>Location Data.</em> We collect location data such as information about your device&#x27;s location, which can be either precise or imprecise. How much information we collect depends on the type and settings of the device you use to access the Website. For example, we may use GPS and other technologies to collect geolocation data that tells us your current location (based on your IP address). You can opt out of allowing us to collect this information either by refusing access to the information or by disabling your Location setting on your device. Note however, if you choose to opt out, you may not be able to use certain aspects of the Services.</li>
+      </ul>
+      <p>‍</p>
+      <h2>‍<strong>2. HOW DO WE USE YOUR INFORMATION?<em>‍</em></strong></h2>
+      <p><em>In Short:  We process your information for purposes based on legitimate business interests, the fulfillment of our contract with you, compliance with our legal obligations, and/or your consent.</em></p>
+      <p>We use personal information collected via our Website for a variety of business purposes described below. We process your personal information for these purposes in reliance on our legitimate business interests, in order to enter into or perform a contract with you, with your consent, and/or for compliance with our legal obligations. We indicate the specific processing grounds we rely on next to each purpose listed below.</p>
+      <p>We use the information we collect or receive:</p>
+      <ul role="list">
+        <li><strong>Fulfill and manage your orders. </strong>We may use your information to fulfill and manage your orders, payments, returns, and exchanges made through the Website.</li>
+        <li><strong>Administer prize draws and competitions.</strong> We may use your information to administer prize draws and competitions when you elect to participate in our competitions.</li>
+        <li><strong>To deliver and facilitate delivery of services to the user.</strong> We may use your information to provide you with the requested service.</li>
+        <li><strong>To respond to user inquiries/offer support to users.</strong> We may use your information to respond to your inquiries and solve any potential issues you might have with the use of our Services.</li>
+        <li><strong>To send you marketing and promotional communications.</strong> We and/or our third-party marketing partners may use the personal information you send to us for our marketing purposes, if this is in accordance with your marketing preferences. For example, when expressing an interest in obtaining information about us or our Website, subscribing to marketing or otherwise contacting us, we will collect personal information from you. You can opt-out of our marketing emails at any time (see the &quot;WHAT ARE YOUR PRIVACY RIGHTS&quot; below).</li>
+        <li><strong>Deliver targeted advertising to you.</strong> We may use your information to develop and display personalized content and advertising (and work with third parties who do so) tailored to your interests and/or location and to measure its effectiveness.<br></li>
+      </ul>
+      <p><br></p>
+      <h2><strong>3. WILL YOUR INFORMATION BE SHARED WITH ANYONE?</strong></h2>
+      <p><em>In Short:  We only share information with your consent, to comply with laws, to provide you with services, to protect your rights, or to fulfill business obligations.</em></p>
+      <p>We may process or share your data that we hold based on the following legal basis:</p>
+      <ul role="list">
+        <li><strong>Consent:</strong> We may process your data if you have given us specific consent to use your personal information for a specific purpose.</li>
+        <li><strong>Legitimate Interests:</strong> We may process your data when it is reasonably necessary to achieve our legitimate business interests.</li>
+        <li><strong>Performance of a Contract:</strong> Where we have entered into a contract with you, we may process your personal information to fulfill the terms of our contract.</li>
+        <li><strong>Legal Obligations:</strong> We may disclose your information where we are legally required to do so in order to comply with applicable law, governmental requests, a judicial proceeding, court order, or legal process, such as in response to a court order or a subpoena (including in response to public authorities to meet national security or law enforcement requirements).</li>
+        <li><strong>Vital Interests:</strong> We may disclose your information where we believe it is necessary to investigate, prevent, or take action regarding potential violations of our policies, suspected fraud, situations involving potential threats to the safety of any person and illegal activities, or as evidence in litigation in which we are involved.</li>
+      </ul>
+      <p>More specifically, we may need to process your data or share your personal information in the following situations:</p>
+      <ul role="list">
+        <li><strong>Business Transfers.</strong> We may share or transfer your information in connection with, or during negotiations of, any merger, sale of company assets, financing, or acquisition of all or a portion of our business to another company</li>
+      </ul>
+      <p>‍</p>
+      <h2><strong>4. DO WE USE COOKIES AND OTHER TRACKING TECHNOLOGIES?</strong></h2>
+      <p><em>In Short:  We may use cookies and other tracking technologies to collect and store your information.</em></p>
+      <p>We may use cookies and similar tracking technologies (like web beacons and pixels) to access or store information. Specific information about how we use such technologies and how you can refuse certain cookies is set out in our Cookie Notice.</p>
+      <p><br></p>
+      <h2><strong>5. HOW LONG DO WE KEEP YOUR INFORMATION?</strong></h2>
+      <p><em>In Short:  We keep your information for as long as necessary to fulfill the purposes outlined in this privacy notice unless otherwise required by law.</em></p>
+      <p>We will only keep your personal information for as long as it is necessary for the purposes set out in this privacy notice, unless a longer retention period is required or permitted by law (such as tax, accounting or other legal requirements). No purpose in this notice will require us keeping your personal information for longer than 1 year.</p>
+      <p>When we have no ongoing legitimate business need to process your personal information, we will either delete or anonymize such information, or, if this is not possible (for example, because your personal information has been stored in backup archives), then we will securely store your personal information and isolate it from any further processing until deletion is possible.</p>
+      <p><br></p>
+      <h2><strong>6. HOW DO WE KEEP YOUR INFORMATION SAFE?</strong></h2>
+      <p><em>In Short:  We aim to protect your personal information through a system of organizational and technical security measures.</em></p>
+      <p>We have implemented appropriate technical and organizational security measures designed to protect the security of any personal information we process. However, despite our safeguards and efforts to secure your information, no electronic transmission over the Internet or information storage technology can be guaranteed to be 100% secure, so we cannot promise or guarantee that hackers, cybercriminals, or other unauthorized third parties will not be able to defeat our security, and improperly collect, access, steal, or modify your information. Although we will do our best to protect your personal information, transmission of personal information to and from our Website is at your own risk. You should only access the Website within a secure environment.</p>
+      <p><br></p>
+      <h2><strong>7. DO WE COLLECT INFORMATION FROM MINORS?</strong></h2>
+      <p><em>In Short:  We do not knowingly collect data from or market to children under 18 years of age.</em></p>
+      <p>We do not knowingly solicit data from or market to children under 18 years of age. By using the Website, you represent that you are at least 18 or that you are the parent or guardian of such a minor and consent to such minor dependentâ€™s use of the Website. If we learn that personal information from users less than 18 years of age has been collected, we will deactivate the account and take reasonable measures to promptly delete such data from our records. If you become aware of any data we may have collected from children under age 18, please contact us at privacy@frontside.com.</p>
+      <p><br></p>
+      <h2><strong>8. WHAT ARE YOUR PRIVACY RIGHTS?</strong></h2>
+      <p><em>In Short:  You may review, change, or terminate your account at any time.</em></p>
+      <p>If you are a resident in the European Economic Area and you believe we are unlawfully processing your personal information, you also have the right to complain to your local data protection supervisory authority. You can find their contact details here: <a href="http://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm">http://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm</a>.</p>
+      <p>If you are a resident in Switzerland, the contact details for the data protection authorities are available here: <a href="https://www.edoeb.admin.ch/edoeb/en/home.html">https://www.edoeb.admin.ch/edoeb/en/home.html</a>.<br></p>
+      <p><strong>Cookies and similar technologies:</strong> Most Web browsers are set to accept cookies by default. If you prefer, you can usually choose to set your browser to remove cookies and to reject cookies. If you choose to remove cookies or reject cookies, this could affect certain features or services of our Website. To opt-out of interest-based advertising by advertisers on our Website visit <a href="http://www.aboutads.info/choices/">http://www.aboutads.info/choices/</a>.</p>
+      <p><br></p>
+      <h2><strong>9. CONTROLS FOR DO-NOT-TRACK FEATURES</strong></h2>
+      <p>Most web browsers and some mobile operating systems and mobile applications include a Do-Not-Track (&quot;DNT&quot;) feature or setting you can activate to signal your privacy preference not to have data about your online browsing activities monitored and collected. At this stage no uniform technology standard for recognizing and implementing DNT signals has been finalized. As such, we do not currently respond to DNT browser signals or any other mechanism that automatically communicates your choice not to be tracked online. If a standard for online tracking is adopted that we must follow in the future, we will inform you about that practice in a revised version of this privacy notice. </p>
+      <p>‍</p>
+      <h2>‍<strong>10. DO CALIFORNIA RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?</strong></h2>
+      <p><em>In Short:  Yes, if you are a resident of California, you are granted specific rights regarding access to your personal information.</em></p>
+      <p>California Civil Code Section 1798.83, also known as the &quot;Shine The Light&quot; law, permits our users who are California residents to request and obtain from us, once a year and free of charge, information about categories of personal information (if any) we disclosed to third parties for direct marketing purposes and the names and addresses of all third parties with which we shared personal information in the immediately preceding calendar year. If you are a California resident and would like to make such a request, please submit your request in writing to us using the contact information provided below.</p>
+      <p>If you are under 18 years of age, reside in California, and have a registered account with the Website, you have the right to request removal of unwanted data that you publicly post on the Website. To request removal of such data, please contact us using the contact information provided below, and include the email address associated with your account and a statement that you reside in California. We will make sure the data is not publicly displayed on the Website, but please be aware that the data may not be completely or comprehensively removed from all our systems (e.g. backups, etc.).</p>
+      <p><br></p>
+      <p><strong>CCPA Privacy Notice</strong><br></p>
+      <p>The California Code of Regulations defines a &quot;resident&quot; as:</p>
+      <p>(1) every individual who is in the State of California for other than a temporary or transitory purpose and</p>
+      <p>(2) every individual who is domiciled in the State of California who is outside the State of California for a temporary or transitory purpose</p>
+      <p>All other individuals are defined as &quot;non-residents.&quot;</p>
+      <p>If this definition of &quot;resident&quot; applies to you, we must adhere to certain rights and obligations regarding your personal information.</p>
+      <p><br></p>
+      <p><strong>What categories of personal information do we collect?</strong></p>
+      <p>We have collected the following categories of personal information in the past twelve (12) months: Identifiers and Personal information categories listed in the California Customer Records statute.</p>
+      <p>We may also collect other personal information outside of these categories instances where you interact with us in-person, online, or by phone or mail in the context of:</p>
+      <ul role="list">
+        <li>Receiving help through our customer support channels;</li>
+        <li>Participation in customer surveys or contests; and</li>
+        <li>Facilitation in the delivery of our Services and to respond to your inquiries.</li>
+      </ul>
+      <p><br></p>
+      <p><strong>How do we use and share your personal information?</strong></p>
+      <p>More information about our data collection and sharing practices can be found in this privacy notice.</p>
+      <p>You may contact us by email at privacy@frontside.com, or by referring to the contact details at the bottom of this document.</p>
+      <p>If you are using an authorized agent to exercise your right to opt-out we may deny a request if the authorized agent does not submit proof that they have been validly authorized to act on your behalf.</p>
+      <p><br></p>
+      <p><strong>Will your information be shared with anyone else?</strong><br></p>
+      <p>We may disclose your personal information with our service providers pursuant to a written contract between us and each service provider. Each service provider is a for-profit entity that processes the information on our behalf.</p>
+      <p>We may use your personal information for our own business purposes, such as for undertaking internal research for technological development and demonstration. This is not considered to be &quot;selling&quot; of your personal data.</p>
+      <p>The Frontside Software, Inc has not disclosed or sold any personal information to third parties for a business or commercial purpose in the preceding 12 months. The Frontside Software, Inc will not sell personal information in the future belonging to website visitors, users and other consumers.</p>
+      <p><br></p>
+      <p><strong>Your rights with respect to your personal data</strong><br></p>
+      <p><em>Right to request deletion of the data - Request to delete<br></em></p>
+      <p>You can ask for the deletion of your personal information. If you ask us to delete your personal information, we will respect your request and delete your personal information, subject to certain exceptions provided by law, such as (but not limited to) the exercise by another consumer of his or her right to free speech, our compliance requirements resulting from a legal obligation or any processing that may be required to protect against illegal activities.<br></p>
+      <p><em>Right to be informed - Request to know<br></em></p>
+      <p>Depending on the circumstances, you have a right to know:</p>
+      <ul role="list">
+        <li>whether we collect and use your personal information;</li>
+        <li>the categories of personal information that we collect;</li>
+        <li>the purposes for which the collected personal information is used;</li>
+        <li>whether we sell your personal information to third parties;</li>
+        <li>the categories of personal information that we sold or disclosed for a business purpose;</li>
+        <li>the categories of third parties to whom the personal information was sold or disclosed for a business purpose; and</li>
+        <li>the business or commercial purpose for collecting or selling personal information.</li>
+      </ul>
+      <p>In accordance with applicable law, we are not obligated to provide or delete consumer information that is de-identified in response to a consumer request or to re-identify individual data to verify a consumer request.<br></p>
+      <p><em>Right to Non-Discrimination for the Exercise of a Consumer’s Privacy Rights</em><br></p>
+      <p>We will not discriminate against you if you exercise your privacy rights.<br></p>
+      <p><em>Verification process<br></em></p>
+      <p>Upon receiving your request, we will need to verify your identity to determine you are the same person about whom we have the information in our system. These verification efforts require us to ask you to provide information so that we can match it with information you have previously provided us. For instance, depending on the type of request you submit, we may ask you to provide certain information so that we can match the information you provide with the information we already have on file, or we may contact you through a communication method (e.g. phone or email) that you have previously provided to us. We may also use other verification methods as the circumstances dictate.<br></p>
+      <p>We will only use personal information provided in your request to verify your identity or authority to make the request. To the extent possible, we will avoid requesting additional information from you for the purposes of verification. If, however, if we cannot verify your identity from the information already maintained by us, we may request that you provide additional information for the purposes of verifying your identity, and for security or fraud-prevention purposes. We will delete such additionally provided information as soon as we finish verifying you.<br></p>
+      <p><em>Other privacy rights</em></p>
+      <ul role="list">
+        <li>you may object to the processing of your personal data</li>
+        <li>you may request correction of your personal data if it is incorrect or no longer relevant, or ask to restrict the processing of the data</li>
+        <li>you can designate an authorized agent to make a request under the CCPA on your behalf. We may deny a request from an authorized agent that does not submit proof that they have been validly authorized to act on your behalf in accordance with the CCPA.</li>
+        <li>you may request to opt-out from future selling of your personal information to third parties. Upon receiving a request to opt-out, we will act upon the request as soon as feasibly possible, but no later than 15 days from the date of the request submission.</li>
+      </ul>
+      <p>To exercise these rights, you can contact us by email at privacy@frontside.com, or by referring to the contact details at the bottom of this document. If you have a complaint about how we handle your data, we would like to hear from you.</p>
+      <p>‍<br></p>
+      <h2><strong>11. DO WE MAKE UPDATES TO THIS NOTICE?</strong></h2>
+      <p><em>In Short:  Yes, we will update this notice as necessary to stay compliant with relevant laws.</em></p>
+      <p>We may update this privacy notice from time to time. The updated version will be indicated by an updated &quot;Revised&quot; date and the updated version will be effective as soon as it is accessible. If we make material changes to this privacy notice, we may notify you either by prominently posting a notice of such changes or by directly sending you a notification. We encourage you to review this privacy notice frequently to be informed of how we are protecting your information.</p>
+      <p>‍<br></p>
+      <h2><strong>12. HOW CAN YOU CONTACT US ABOUT THIS NOTICE?</strong></h2>
+      <p>If you have questions or comments about this notice, you may email us at privacy@frontside.com or by post to:<br></p>
+      <p>The Frontside Software, Inc</p>
+      <p>2301 W Anderson Ln #107</p>
+      <p>Austin, TX 78757</p>
+      <p>United States</p>
+      <p><br></p>
+      <h2><strong>13. HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA WE COLLECT FROM YOU?</strong></h2>
+      <p>Based on the applicable laws of your country, you may have the right to request access to the personal information we collect from you, change that information, or delete it in some circumstances. To request to review, update, or delete your personal information, please visit: privacy@frontside.com. We will respond to your request within 30 days.</p>
+      <p>‍</p>
+      <p>‍</p>
+    </div>
+  </div>
+  <footer class="footerwrapper w-container">
+    <nav class="navigation">
+      <a href="/" class="footerlink">Home</a>
+      <a href="/about" class="footerlink">About</a>
+      <a href="/consulting" class="footerlink">Consulting</a>
+      <a href="/tools" class="footerlink">Tools</a>
+      <a href="/blog" class="footerlink">Blog</a>
+      <a href="/podcast" class="footerlink">Podcast</a>
+      <a href="/contact" class="footerlink">Contact</a>
+    </nav>
+    <a href="/" class="footer-symbol w-inline-block"><img src="images/fs-webclip.png" loading="lazy" width="32.5" alt="" class="image-6"></a>
+    <p class="footer-notes"><br>2301 W Anderson Ln #107<br>Austin, Texas 78757<br>+1 (800) 493-4589</p>
+    <p class="copyright">© 2005-2020 THE FRONTSIDE SOFTWARE, INC. ALL RIGHTS RESERVED.</p>
+    <div class="copyright w-richtext">
+      <p>
+        <a href="/code-of-conduct">Code of Conduct</a> | <a href="/privacy-policy" aria-current="page" class="w--current">Privacy Policy </a>
+      </p>
+    </div>
+  </footer>
+  <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5f7f19d60c33ef0c409a8bf8" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+  <script src="js/webflow.js" type="text/javascript"></script>
+  <!-- [if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
+</body>
+</html>

--- a/static/tools.html
+++ b/static/tools.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Tue Jan 05 2021 16:31:51 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Jan 08 2021 14:25:32 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5f85bf7b1a80ea76947f56fd" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -19,6 +19,7 @@
   <link href="css/webflow.css" rel="stylesheet" type="text/css">
   <link href="css/frontside-website.webflow.css" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="https://use.typekit.net/gyc5wys.css" />
+
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
@@ -112,7 +113,7 @@
       <p>Ready-to-use with Jest and Cypress, BigTest Interactors make it easy to test UIs at scale while keeping accessibility at the core.</p>
       <a href="https://frontside.com/bigtest/" target="_blank" rel="nofollow" class="button topage w-button">Get started</a>
     </div>
-    <div class="feature-image centered"><img src="images/interactors-teaser1.5x.png" loading="eager" srcset="images/interactors-teaser1.5x.png 500w, images/interactors-teaser1.5x.png 941w" sizes="400px" alt="" class="bigtestside"></div>
+    <div class="feature-image centered"><img src="images/interactors-teaser1.5x.png" loading="eager" srcset="images/interactors-teaser1.5x-p-500.png 500w, images/interactors-teaser1.5x.png 941w" sizes="400px" alt="" class="bigtestside"></div>
   </section>
   <section class="feature-wrapper notopspace w-container">
     <div class="feature-text">
@@ -164,6 +165,11 @@
     <a href="/" class="footer-symbol w-inline-block"><img src="images/fs-webclip.png" loading="lazy" width="32.5" alt="" class="image-6"></a>
     <p class="footer-notes"><br>2301 W Anderson Ln #107<br>Austin, Texas 78757<br>+1 (800) 493-4589</p>
     <p class="copyright">© 2005-2020 THE FRONTSIDE SOFTWARE, INC. ALL RIGHTS RESERVED.</p>
+    <div class="copyright w-richtext">
+      <p>
+        <a href="/code-of-conduct">Code of Conduct</a> | <a href="/privacy-policy">Privacy Policy </a>
+      </p>
+    </div>
   </footer>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5f7f19d60c33ef0c409a8bf8" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="js/webflow.js" type="text/javascript"></script>


### PR DESCRIPTION
## Motivation

We were missing a Code of Conduct for your community efforts, and a Privacy Policy for the website.

## Approach 

I used [Contributor Covenant](https://www.contributor-covenant.org) code as it was the most popular among OSS projects for the Code of Conduct. The Privacy Policy I used a generator and inputed what we use on the website (mainly Google Analytics) and the contact form. 

[Preview of Code of Conduct](https://deploy-preview-112--frontside.netlify.app/code-of-conduct)
[Preview of Privacy Policy](https://deploy-preview-112--frontside.netlify.app/privacy-policy)