### PR TITLE
Fixes og:url meta tag

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -13,6 +13,7 @@ export default function TemplateWrapper({
   description,
   title,
   image,
+  path
 }) {
   return (
     <StaticQuery
@@ -83,7 +84,7 @@ export default function TemplateWrapper({
               }
             />
             <meta property="og:type" content="website" />
-            <meta property="og:url" content={data.site.siteMetadata.siteUrl} />
+            
             <meta
               property="og:image"
               content={
@@ -93,6 +94,11 @@ export default function TemplateWrapper({
               }
             />
           </Helmet>
+          { path && typeof path === 'string' ? (
+            <Helmet>
+              <meta property="og:url" content={`${data.site.siteMetadata.siteUrl}${path}`} />
+            </Helmet>
+          ) : <></>}
           <Navbar />
 
           {children}

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -82,6 +82,7 @@ const BlogPost = ({ data: { markdownRemark: post } }) => {
           ? null
           : post.frontmatter.img.childImageSharp.resolutions.src
       }
+      path={post.fields.slug}
     >
       <BlogPostTemplate
         content={post.html}


### PR DESCRIPTION
## Motivation

LinkedIn always generated the wrong preview for our links. LinkedIn link inspector said that the problem was in our canonical URL, but that was not the case. After further investigation I discovered that `og:url` was set to `/` on every page, thus causing social media outlets who considered that tag above the actual URL to render the wrong preview.

## Approach

I added a `path` optional parameter to `Layout` so we could pass the blog entries path to construct a `og:url`. If there's not an explicitly set meta tag, we simply don't add the tag, it's better than adding a wrong one as most services will default to the actual URL.