### PR TITLE
Plausible analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,11 @@ At the moment we have a provisional manual process to adjust the webflow generat
 1. Download ZIP of files from webflow
 2. Find and replace for all links in navs of the generated files from `*.html` to `/*` (done manually at the moment).
 3. Find and replace all `target="_blank"` and replace with `target="_blank" rel="nofollow"`
-4. Add hidden field to `contat.html` on top of the form element:
+4. Find and replace with nothing (toxic tracking that webflow is pushing although I disabled it):
+
 ```
-<input type="hidden" name="form-name" value="contact" />
-<div hidden>
-  <label>
-    Don’t fill this out:
-    <input name="bot-field" onChange={this.handleChange} />
-  </label>
-</div>
+  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-44597640-1"></script>
+  <script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-44597640-1', {'anonymize_ip': false});</script>
 ```
 5. Replace typekit's script loading for stylesheet.
 ```

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -148,19 +148,6 @@ module.exports = {
       },
     },
     {
-      resolve: 'gatsby-plugin-hotjar',
-      options: {
-        id: 859026,
-        sv: 6,
-      },
-    },
-    {
-      resolve: 'gatsby-plugin-google-analytics',
-      options: {
-        trackingId: 'UA-44597640-1',
-      },
-    },
-    {
       resolve: 'gatsby-plugin-sitemap',
       options: {
         query: `

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -2,6 +2,7 @@ const React = require("react")
 
 exports.onRenderBody = ({ setHeadComponents }) => {
   setHeadComponents([
-    <link rel="stylesheet" href="https://use.typekit.net/gyc5wys.css" />
+    <link rel="stylesheet" href="https://use.typekit.net/gyc5wys.css" />,
+    <script async="" defer="" data-domain="frontside.com" src="https://plausible.io/js/plausible.js"></script>
   ])
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "dateformat": "3.0.3",
     "gatsby": "^2.4.0",
     "gatsby-image": "^2.2.41",
-    "gatsby-plugin-google-analytics": "2.1.35",
     "gatsby-plugin-mailchimp": "^5.2.2",
     "gatsby-plugin-manifest": "^2.2.41",
     "gatsby-plugin-netlify": "^2.1.32",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "gatsby": "^2.4.0",
     "gatsby-image": "^2.2.41",
     "gatsby-plugin-google-analytics": "2.1.35",
-    "gatsby-plugin-hotjar": "^1.0.1",
     "gatsby-plugin-mailchimp": "^5.2.2",
     "gatsby-plugin-manifest": "^2.2.41",
     "gatsby-plugin-netlify": "^2.1.32",

--- a/static/about.html
+++ b/static/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Sat Mar 20 2021 12:04:18 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Mar 26 2021 11:33:12 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5f8432592616248537dab3da" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -23,18 +23,8 @@
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
-  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-44597640-1"></script>
-  <script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-44597640-1', {'anonymize_ip': false});</script><!--  Hotjar Tracking Code for https://frontside.com/  -->
-  <script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:859026,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
+
+  <script async="" defer="" data-domain="frontside.com" src="https://plausible.io/js/plausible.js"></script>
 </head>
 <body class="fs-body">
   <div data-collapse="medium" data-animation="over-right" data-duration="200" data-doc-height="1" data-easing="ease-in-out-circ" data-no-scroll="1" role="banner" class="navbar w-nav">

--- a/static/code-of-conduct.html
+++ b/static/code-of-conduct.html
@@ -22,18 +22,6 @@
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
-  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-44597640-1"></script>
-  <script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-44597640-1', {'anonymize_ip': false});</script><!--  Hotjar Tracking Code for https://frontside.com/  -->
-  <script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:859026,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
 </head>
 <body class="fs-body">
   <div data-collapse="medium" data-animation="over-right" data-duration="200" data-doc-height="1" data-easing="ease-in-out-circ" data-no-scroll="1" role="banner" class="navbar w-nav">

--- a/static/consulting.html
+++ b/static/consulting.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Sat Mar 20 2021 12:04:18 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Mar 26 2021 11:33:12 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5f85a0bba25bf148ce79acb4" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -23,18 +23,8 @@
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
-  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-44597640-1"></script>
-  <script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-44597640-1', {'anonymize_ip': false});</script><!--  Hotjar Tracking Code for https://frontside.com/  -->
-  <script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:859026,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
+
+  <script async="" defer="" data-domain="frontside.com" src="https://plausible.io/js/plausible.js"></script>
 </head>
 <body class="fs-body">
   <div data-collapse="medium" data-animation="over-right" data-duration="200" data-doc-height="1" data-easing="ease-in-out-circ" data-no-scroll="1" role="banner" class="navbar w-nav">

--- a/static/contact-thanks.html
+++ b/static/contact-thanks.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Sat Mar 20 2021 12:04:18 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Mar 26 2021 11:33:12 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5fb254240cbef141bb1db2c7" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -21,18 +21,8 @@
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
-  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-44597640-1"></script>
-  <script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-44597640-1', {'anonymize_ip': false});</script><!--  Hotjar Tracking Code for https://frontside.com/  -->
-  <script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:859026,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
+
+  <script async="" defer="" data-domain="frontside.com" src="https://plausible.io/js/plausible.js"></script>
 </head>
 <body class="fs-body">
   <div data-collapse="medium" data-animation="over-right" data-duration="200" data-doc-height="1" data-easing="ease-in-out-circ" data-no-scroll="1" role="banner" class="navbar w-nav">

--- a/static/contact.html
+++ b/static/contact.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Sat Mar 20 2021 12:04:18 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Mar 26 2021 11:33:12 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5faea4534d61150d591f8411" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -21,18 +21,8 @@
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
-  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-44597640-1"></script>
-  <script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-44597640-1', {'anonymize_ip': false});</script><!--  Hotjar Tracking Code for https://frontside.com/  -->
-  <script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:859026,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
+
+  <script async="" defer="" data-domain="frontside.com" src="https://plausible.io/js/plausible.js"></script>
 </head>
 <body class="fs-body">
   <div data-collapse="medium" data-animation="over-right" data-duration="200" data-doc-height="1" data-easing="ease-in-out-circ" data-no-scroll="1" role="banner" class="navbar w-nav">
@@ -98,12 +88,13 @@
   <div class="midwrapper">
     <div data-netlify="true" data-netlify-honeypot="bot-field" class="form-block w-form">
       <form id="wf-form-contact" name="wf-form-contact" data-name="contact" action="/contact-thanks/" method="post" class="form">
-        <input type="hidden" name="form-name" value="contact" />
-        <div hidden>
-          <label>
-            Don’t fill this out:
-            <input name="bot-field" onChange={this.handleChange} />
-          </label>
+        <div class="w-embed"><input type="hidden" name="form-name" value="contact">
+          <div hidden="">
+            <label>
+              Don’t fill this out:
+              <input name="bot-field" onchange="{this.handleChange}">
+            </label>
+          </div>
         </div>
         <div class="form-row">
           <div class="input-border-2"><input type="text" class="text-field w-input" maxlength="256" name="name" data-name="name" placeholder="Your name" id="name" required=""></div>

--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Sat Mar 20 2021 12:04:18 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Mar 26 2021 11:33:12 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5f7f19d60c33effa4a9a8bf9" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -23,18 +23,8 @@
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
-  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-44597640-1"></script>
-  <script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-44597640-1', {'anonymize_ip': false});</script><!--  Hotjar Tracking Code for https://frontside.com/  -->
-  <script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:859026,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
+
+  <script async="" defer="" data-domain="frontside.com" src="https://plausible.io/js/plausible.js"></script>
 </head>
 <body class="fs-body">
   <div data-collapse="medium" data-animation="over-right" data-duration="200" data-doc-height="1" data-easing="ease-in-out-circ" data-no-scroll="1" role="banner" class="navbar w-nav">

--- a/static/privacy-policy.html
+++ b/static/privacy-policy.html
@@ -22,18 +22,6 @@
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
-  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-44597640-1"></script>
-  <script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-44597640-1', {'anonymize_ip': false});</script><!--  Hotjar Tracking Code for https://frontside.com/  -->
-  <script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:859026,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
 </head>
 <body class="fs-body">
   <div data-collapse="medium" data-animation="over-right" data-duration="200" data-doc-height="1" data-easing="ease-in-out-circ" data-no-scroll="1" role="banner" class="navbar w-nav">

--- a/static/tools.html
+++ b/static/tools.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!--  This site was created in Webflow. http://www.webflow.com  -->
-<!--  Last Published: Sat Mar 20 2021 12:04:18 GMT+0000 (Coordinated Universal Time)  -->
+<!--  Last Published: Fri Mar 26 2021 11:33:12 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5f85bf7b1a80ea76947f56fd" data-wf-site="5f7f19d60c33ef0c409a8bf8">
 <head>
   <meta charset="utf-8">
@@ -23,18 +23,8 @@
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
-  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-44597640-1"></script>
-  <script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-44597640-1', {'anonymize_ip': false});</script><!--  Hotjar Tracking Code for https://frontside.com/  -->
-  <script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:859026,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
+
+  <script async="" defer="" data-domain="frontside.com" src="https://plausible.io/js/plausible.js"></script>
 </head>
 <body class="fs-body">
   <div data-collapse="medium" data-animation="over-right" data-duration="200" data-doc-height="1" data-easing="ease-in-out-circ" data-no-scroll="1" role="banner" class="navbar w-nav">

--- a/yarn.lock
+++ b/yarn.lock
@@ -6221,13 +6221,6 @@ gatsby-page-utils@^0.0.39:
     lodash "^4.17.15"
     micromatch "^3.1.10"
 
-gatsby-plugin-google-analytics@2.1.35:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.1.35.tgz#d47ce2510a82f4f59f45c2a074940f2783da4241"
-  integrity sha512-csZc0LgpMAw0cD27zpGKYHw41veYLLjoxT2guTY1hC3/tMRNZ38XUvO4TKcFGjgobppOg/UuLNF31YzjwJRmpA==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
-
 gatsby-plugin-mailchimp@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-mailchimp/-/gatsby-plugin-mailchimp-5.2.2.tgz#bed94cb70b9d91267329a5e6a0220e821d8ff6e8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6228,13 +6228,6 @@ gatsby-plugin-google-analytics@2.1.35:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-gatsby-plugin-hotjar@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-hotjar/-/gatsby-plugin-hotjar-1.0.1.tgz#f5703d7d2a354752e20230a0074d53c7287d8950"
-  integrity sha512-1iZIftJin3Ti51ho7HiGes2ZiXZhU0/sSe6OCvULy3F9hSpADrX5jU48ajnZnrS1O0lf7pyVfjvBBpXOawASHw==
-  dependencies:
-    babel-runtime "^6.26.0"
-
 gatsby-plugin-mailchimp@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-mailchimp/-/gatsby-plugin-mailchimp-5.2.2.tgz#bed94cb70b9d91267329a5e6a0220e821d8ff6e8"


### PR DESCRIPTION
## Motivation

We've used Plausible for the bigtest and openmic websites, and it has been great so far. Not only does it respect our visitors privacy, and prevents adtech from using and cross-selling their data through our websites, but it actually gives us simpler and more comprehensible information. 

In this website, we used hotjar, which is very invasive. It's been installed for a while, but we have never gotten a single interesting insight from it. It would've made no sense to remove GA but leave hotjar, so I'm removing both. 

## Approach

I made the changes on the webflow platform, and updated the README on this repo to the instructions that are needed now when integrating the exported pages. I removed GA and hotjar from Gatsby, and added plausible's snippet. 
