### PR TITLE
Mount effection website at /effection

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,6 +18,12 @@ to = "https://bigtest.netlify.app/bigtest/:splat"
 
 [[redirects]]
 force = true
+from = "/effection/*"
+status = 200
+to = "https://effection.netlify.app/effection/:splat"
+
+[[redirects]]
+force = true
 from = "https://frontside.io/*"
 status = 301
 to = "https://frontside.com/:splat"


### PR DESCRIPTION
## Motivation
Rather than maintain a separate subdomain for our different technologies, we just hang them off of the main website. This is convenient and good for branding.

## Approach

Add it to the the netlify.toml! (this is borrowed from the same technique used to handle frontside.com/bigtest)