### PR TITLE
fix: podcast ordering, last two were flipped

### DIFF
--- a/src/templates/blog-list.js
+++ b/src/templates/blog-list.js
@@ -38,13 +38,13 @@ const PodcastFeaturedEpisodes = [
   },
   {
     fromPodcast: true,
-    slug: '/podcast/intro-to-rush-js-with-co-author-pete-gonzales/',
-    image: '/img/2020-pod-rush.png',
+    slug: '/podcast/type-systems-with-reason-ml-london-organizer-marcel-cutts-and-shane-wilson/',
+    image: '/img/2020-reason-podcast.png',
   },
   {
     fromPodcast: true,
-    slug: '/podcast/repkgs-reasonml',
-    image: '/img/2020-reason-podcast.png',
+    slug: '/podcast/intro-to-rush-js-with-co-author-pete-gonzales/',
+    image: '/img/2020-pod-rush.png',
   },
 ];
 


### PR DESCRIPTION
## Motivation

The last two "featured" podcasts were out of order and one had an incorrect slug.

The links on the [blog](https://deploy-preview-146--frontside.netlify.app/blog) page should match index [4](https://deploy-preview-146--frontside.netlify.app/podcast/type-systems-with-reason-ml-london-organizer-marcel-cutts-and-shane-wilson/) and index [5](https://deploy-preview-146--frontside.netlify.app/podcast/intro-to-rush-js-with-co-author-pete-gonzales/) of the featured podcasts.