### PR TITLE
Effection API redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,6 +18,12 @@ to = "https://bigtest.netlify.app/bigtest/:splat"
 
 [[redirects]]
 force = true
+from = "/effection/api/*"
+status = 200
+to = "https://v2--effection-api.netlify.app/:splat"
+
+[[redirects]]
+force = true
 from = "/effection/*"
 status = 200
 to = "https://effection.netlify.app/effection/:splat"


### PR DESCRIPTION
## Motivation

Effection TSdocs instance need to live in `/effection/api/` but we cannot register it within `/effection` netlify because we'd commit a double redirect, which is invalid. So we'll register it a the level of this website

## Approach 

Added a redirect rule to the production netlify instance of effection tsdocs