### PR TITLE
Add BigTest full name, add cross links

### DIFF
--- a/src/blog/2021-01-15-design-tokens-and-components.md
+++ b/src/blog/2021-01-15-design-tokens-and-components.md
@@ -192,3 +192,35 @@ Re-assigning design tokens to per-component variables makes it possible to defin
 <p class="blog-post--guest-intro">
     <a href="https://varya.me/" target="_blank">Varya Stepanova</a> is a design systems architect—and co-creator of <a href="http://getbem.com/" target="_blank" rel="nofollow">BEM</a>—based in Finland. Varya has improved the way dozens of teams, large and small, develop and evolve their design process towards better collaboration among stakeholders.
 </p>
+
+<aside class="posts-list-list">
+  <h2>Related article:</h2>
+  <div class="posts-list-entry">
+    <h3 class="posts-list-title">
+      <a href="/blog/2021-04-07-helping-designers-and-developers-storybook/">
+        Unleashing the Genie: Helping both designers and developers with Storybook
+      </a>
+    </h3>
+    <p>
+      Good documentation is key to design systems. However, what "good" means varies according to the reader. This article will go through tips to generate documentations for designers and developers from a single Storybook—keep everyone happy with minimum effort!
+    </p>
+    <a href="/blog/2021-04-07-helping-designers-and-developers-storybook/" class="post-link">
+      Continue reading
+      <span class="post-link--arrow">→</span>
+    </a>
+  </div>
+  <div class="posts-list-entry">
+    <h3 class="posts-list-title">
+      <a href="/blog/2021-08-04-interactors-design-systems/">
+        Interactors: the design systems testing ally
+      </a>
+    </h3>
+    <p>
+      Components from a design system make building UIs easy. It should be just as easy to test them. Interactors enable more robust tests for component-based UIs, and improve component libraries' maintainability.
+    </p>
+    <a href="/blog/2021-08-04-interactors-design-systems/" class="post-link">
+      Continue reading
+      <span class="post-link--arrow">→</span>
+    </a>
+  </div>
+</aside>

--- a/src/blog/2021-04-07-helping-designers-and-developers-storybook.md
+++ b/src/blog/2021-04-07-helping-designers-and-developers-storybook.md
@@ -153,4 +153,18 @@ The tips and tricks written above are indeed not the only things that one can do
       <span class="post-link--arrow">→</span>
     </a>
   </div>
+  <div class="posts-list-entry">
+    <h3 class="posts-list-title">
+      <a href="/blog/2021-08-04-interactors-design-systems/">
+        Interactors: the design systems testing ally
+      </a>
+    </h3>
+    <p>
+      Components from a design system make building UIs easy. It should be just as easy to test them. Interactors enable more robust tests for component-based UIs, and improve component libraries' maintainability.
+    </p>
+    <a href="/blog/2021-08-04-interactors-design-systems/" class="post-link">
+      Continue reading
+      <span class="post-link--arrow">→</span>
+    </a>
+  </div>
 </aside>

--- a/src/blog/2021-08-04-interactors-design-systems.md
+++ b/src/blog/2021-08-04-interactors-design-systems.md
@@ -1,9 +1,9 @@
 ---
 templateKey: blog-post
 title: >-
-  Interactors: the design systems testing ally
+  BigTest Interactors: the design systems testing ally
 date: 2021-08-04T05:00:00.000Z
-author: Charles Lowell, Taras Mankovski, Jeffrey Cherewaty
+author: Charles Lowell, Jeffrey Cherewaty
 description: >-
   Components from a design system make building UIs easy. It should be just as easy to test them. Interactors enable more robust tests for component-based UIs, and improve component libraries' maintainability.
 tags:
@@ -31,9 +31,9 @@ To effectively write a test using this date picker, we had to include specifics 
 
 There's a well-trod design pattern for fixing this problem: [page objects](https://www.martinfowler.com/bliki/PageObject.html). They're object-oriented classes that serve as an interface. As an application matures alongside its accompanying tests, page objects act as a buffer and a more explicit API for the tests to interact with the application.
 
-## Introducing Interactors
+## Introducing BigTest Interactors
 
-At Frontside, we've built [Interactors](https://frontside.com/bigtest/interactors), a library inspired by page objects that helps teams structure, share, and reuse their UI testing practices.
+At Frontside, we've built [BigTest Interactors](https://frontside.com/bigtest/interactors) (`@bigtest/interactor`), a library inspired by page objects that helps teams structure, share, and reuse their UI testing practices.
 
 Interactors evolve the idea of a page object. Modern applications are usually arranged into composable components, and the "page" is no longer the dominant unit of organization. An Interactor is similarly composable, and can abstract any level of object in the DOM hierarchy.
 
@@ -52,6 +52,8 @@ Let's take a closer look at each of these advantages.
 We provide basic [built-in Interactors](https://frontside.com/bigtest/docs/interactors/built-in-dom) that correspond to HTML elements, like `button`, `link`, and `checkbox`. Using these alone, you could interact with and assert the majority of cases of a web UI. Take the following example of a collapsable navigation menu test:
 
 ```js
+import { Button, Link, Heading } from `@bigtest/interactor`;
+
 it('goes to international news page with mobile menu', () => {
   cy.do([
 		Button({'aria-label': 'Show Navigation Menu'}).click(),
@@ -119,7 +121,7 @@ Interactors not only check for presence before committing an action in the UI, t
 
 ## Try out Interactors!
 
-If you're still not sure about trying out Interactors, take a look at this [pull request in FOLIO](https://github.com/folio-org/stripes-testing/pull/112), an open-source project, adopting Interactors in their component library:
+If you're still not sure about trying out BigTest Interactors, take a look at this [pull request in FOLIO](https://github.com/folio-org/stripes-testing/pull/112), an open-source project, adopting Interactors in their component library:
 
 ![Screenshot of code diff resulting in refactoring a test using React Testing Library to use Interactors](/img/2021-08-04-interactors-design-system/diff-react-testing-library-vs-interactors.png)
 

--- a/src/templates/blog-list.js
+++ b/src/templates/blog-list.js
@@ -74,15 +74,14 @@ export default function BlogPage({
 
   if (page === 1) {
     let postsAndEpisodes = [
-      formattedPosts[0],
+      ...formattedPosts.slice(0, 3),
       { ...podcastEpisodes[0], ...PodcastFeaturedEpisodes[0] },
       { ...podcastEpisodes[1], ...PodcastFeaturedEpisodes[1] },
-      ...formattedPosts.slice(1, 3),
+      ...formattedPosts.slice(3, 6),
       { ...podcastEpisodes[2], ...PodcastFeaturedEpisodes[2] },
       { ...podcastEpisodes[3], ...PodcastFeaturedEpisodes[3] },
-      ...formattedPosts.slice(3, 5),
+      ...formattedPosts.slice(6),
       { ...podcastEpisodes[4], ...PodcastFeaturedEpisodes[4] },
-      ...formattedPosts.slice(5),
       { ...podcastEpisodes[5], ...PodcastFeaturedEpisodes[5] },
     ];
     formattedPosts = postsAndEpisodes;

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -23,7 +23,7 @@ const TagRoute = ({ data, pageContext }) => {
         posts={posts.map(({ node }) => ({
           id: node.id,
           slug: node.slug,
-          title: node.markdown.frontmatter.title,
+          title: node.title,
           date: node.markdown.frontmatter.date,
           description: node.markdown.frontmatter.description,
           excerpt: node.markdown.excerpt,

--- a/static/index.html
+++ b/static/index.html
@@ -146,6 +146,16 @@
     <div class="entries-list">
       <div class="colorborderwrapping entrypreview">
         <div class="entry-preview">
+          <a href="/blog/2021-08-04-interactors-design-systems/" class="articlelink w-inline-block"><img src="/img/2021-interactors-design.png" loading="lazy" alt="" class="article-preview">
+            <h3>Interactors: the design systems testing ally</h3>
+            <p class="meta">By Charles Lowell and Jeffrey Cherewaty</p>
+            <p class="article-text">Components from a design system make building UIs easy. It should be just as easy to test them. Interactors enable more robust tests for component-based UIs, and improve component libraries' maintainability.</p>
+          </a>
+          <a href="/blog/2021-08-04-interactors-design-systems/" class="entry-read-more">Continue reading →</a>
+        </div>
+      </div>
+      <div class="colorborderwrapping entrypreview">
+        <div class="entry-preview">
           <a href="/blog/2021-05-14-avoid-cloud-native-churn-with-backstage/" class="articlelink w-inline-block"><img src="/img/2021-backstage-dx/avoid-developer-churn-with-backstage.png" loading="lazy" alt="" class="article-preview">
             <h3>Relieve developers’ churn in your Cloud native strategy with Backstage</h3>
             <p class="meta">By Taras Mankovski</p>
@@ -154,16 +164,6 @@
             </p>
           </a>
           <a href="/blog/2021-05-14-avoid-cloud-native-churn-with-backstage/" class="entry-read-more">Continue reading →</a>
-        </div>
-      </div>
-      <div class="colorborderwrapping entrypreview">
-        <div class="entry-preview">
-          <a href="/blog/2021-04-07-helping-designers-and-developers-storybook/" class="articlelink w-inline-block"><img src="/img/2021-helping-designers-and-developers-storybook.png" loading="lazy" alt="" class="article-preview">
-            <h3>Unleashing the Genie: Helping both designers and developers with Storybook </h3>
-            <p class="meta">By Varya Stepanova</p>
-            <p class="article-text">Good documentation is key to design systems. However, what "good" means varies according to the reader. This article will go through tips to generate documentations for designers and developers from a single Storybook—keep everyone happy with minimum effort!</p>
-          </a>
-          <a href="/blog/2021-04-07-helping-designers-and-developers-storybook//" class="entry-read-more">Continue reading →</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Motivation

Need to clarify it's `@bigtest/interactor` what we're talking about 

## Approach
- Added cross-links in the website
- Removed Taras as author - he's written the previous articles; also, we'll reserve him for cloud native content
- Added "BigTest Interactors" in narrative in some place, plus added `@bigtest/interactor` in the introducing section and an import in the code example (not sure if it's ok to only do that import, should I add an ellipsis or the whole import including cypress too?)