### PR TITLE
Add 301 redirect for old interactors path to new

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,7 +14,7 @@ framework = "gatsby"
 force = true
 from = "/bigtest/docs/interactors"
 status = 301
-to = "https://interactors.netlify.app/interactors/:splat"
+to = "https://frontside.com/interactors"
 
 [[redirects]]
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,12 @@ framework = "gatsby"
 
 [[redirects]]
 force = true
+from = "/bigtest/docs/interactors"
+status = 301
+to = "https://interactors.netlify.app/interactors/:splat"
+
+[[redirects]]
+force = true
 from = "/bigtest/*"
 status = 200
 to = "https://bigtest.netlify.app/bigtest/:splat"


### PR DESCRIPTION
## Motivation

To address #156

## Approach

- will redirect from the old `/bigtest/docs/interactors` to the new `interactors.netlify.app/interactors`
- used `301` for permanent redirect 