### PR TITLE
Add asterik to capture all old links

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@ framework = "gatsby"
 
 [[redirects]]
 force = true
-from = "/bigtest/docs/interactors"
+from = "/bigtest/docs/interactors/*"
 status = 301
 to = "https://frontside.com/interactors"
 


### PR DESCRIPTION
## Motivation

#157 was merged before it was finished

## Approach

Need to add `*` so that _all_ old links will redirect to the new site.

Didn't add `:splat` because if we rename or remove old pages, people with the old links will land on the netlify error page.