### PR TITLE
Add status 200 redirects for all API docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,6 +24,12 @@ to = "https://bigtest.netlify.app/bigtest/:splat"
 
 [[redirects]]
 force = true
+from = "/effection/api"
+status = 200
+to = "https://frontside.com/effection/api/index.html"
+
+[[redirects]]
+force = true
 from = "/effection/api/*"
 status = 200
 to = "https://v2--effection-api.netlify.app/:splat"
@@ -36,9 +42,21 @@ to = "https://effection.netlify.app/effection/:splat"
 
 [[redirects]]
 force = true
+from = "/interactors/html/api"
+status = 200
+to = "https://frontside.com/interactors/html/api/index.html"
+
+[[redirects]]
+force = true
 from = "/interactors/html/api/*"
 status = 200
 to = "https://main--interactors-html-api.netlify.app/:splat"
+
+[[redirects]]
+force = true
+from = "/interactors/mui/api"
+status = 200
+to = "https://frontside.com/interactors/mui/api/index.html"
 
 [[redirects]]
 force = true


### PR DESCRIPTION
## Motivation

If you go to:

- https://frontside.com/effection/api
- https://frontside.com/interactors/html/api
- https://frontside.com/interactors/mui/api

None of the css gets loaded in. But they do if you go to:

- https://frontside.com/effection/api/index.html
- https://frontside.com/interactors/html/api/index.html
- https://frontside.com/interactors/mui/api/index.html

## Approach

Add redirects specifically for those landing page URLs. Wherever we link them we could include "index.html" but there's a chance someone might still find themselves on `x/api` without the `index.html` and get the ugly no-style version.

Used `200` instead of `301` because it's not so much a "oops, that's an old URL" but just part of a workaround due to `typedocs` limitations on setting the `baseUrl`.