### PR TITLE
Use redirect 301 instead of 200

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,7 +24,7 @@ to = "https://bigtest.netlify.app/bigtest/:splat"
 
 [[redirects]]
 force = true
-from = "/effection/api"
+from = "/effection/api/"
 status = 200
 to = "/effection/api/index.html"
 
@@ -42,7 +42,7 @@ to = "https://effection.netlify.app/effection/:splat"
 
 [[redirects]]
 force = true
-from = "/interactors/html/api"
+from = "/interactors/html/api/"
 status = 200
 to = "/interactors/html/api/index.html"
 
@@ -54,7 +54,7 @@ to = "https://main--interactors-html-api.netlify.app/:splat"
 
 [[redirects]]
 force = true
-from = "/interactors/mui/api"
+from = "/interactors/mui/api/"
 status = 200
 to = "/interactors/mui/api/index.html"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,8 +24,8 @@ to = "https://bigtest.netlify.app/bigtest/:splat"
 
 [[redirects]]
 force = true
-from = "/effection/what/"
-status = 200
+from = "/effection/api"
+status = 301
 to = "/effection/api/index.html"
 
 [[redirects]]
@@ -42,8 +42,8 @@ to = "https://effection.netlify.app/effection/:splat"
 
 [[redirects]]
 force = true
-from = "/interactors/huh"
-status = 200
+from = "/interactors/html/api"
+status = 301
 to = "/interactors/html/api/index.html"
 
 [[redirects]]
@@ -54,8 +54,8 @@ to = "https://main--interactors-html-api.netlify.app/:splat"
 
 [[redirects]]
 force = true
-from = "/interactors/mui/api/"
-status = 200
+from = "/interactors/mui/api"
+status = 301
 to = "/interactors/mui/api/index.html"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -26,7 +26,7 @@ to = "https://bigtest.netlify.app/bigtest/:splat"
 force = true
 from = "/effection/api"
 status = 200
-to = "https://frontside.com/effection/api/index.html"
+to = "/effection/api/index.html"
 
 [[redirects]]
 force = true
@@ -44,7 +44,7 @@ to = "https://effection.netlify.app/effection/:splat"
 force = true
 from = "/interactors/html/api"
 status = 200
-to = "https://frontside.com/interactors/html/api/index.html"
+to = "/interactors/html/api/index.html"
 
 [[redirects]]
 force = true
@@ -56,7 +56,7 @@ to = "https://main--interactors-html-api.netlify.app/:splat"
 force = true
 from = "/interactors/mui/api"
 status = 200
-to = "https://frontside.com/interactors/mui/api/index.html"
+to = "/interactors/mui/api/index.html"
 
 [[redirects]]
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,7 +24,7 @@ to = "https://bigtest.netlify.app/bigtest/:splat"
 
 [[redirects]]
 force = true
-from = "/effection/api/"
+from = "/effection/what/"
 status = 200
 to = "/effection/api/index.html"
 
@@ -42,7 +42,7 @@ to = "https://effection.netlify.app/effection/:splat"
 
 [[redirects]]
 force = true
-from = "/interactors/html/api/"
+from = "/interactors/huh"
 status = 200
 to = "/interactors/html/api/index.html"
 


### PR DESCRIPTION
## Motivation

Follow up to #169

## Approach

Use 301 instead of 200

https://deploy-preview-171--frontside.netlify.app/effection/api/
https://deploy-preview-171--frontside.netlify.app/interactors/html/api/
https://deploy-preview-171--frontside.netlify.app/interactors/mui/api/