### PR TITLE
Fixes nav alignement issue

### DIFF
--- a/src/components/navbar/navbar.css.ts
+++ b/src/components/navbar/navbar.css.ts
@@ -86,6 +86,7 @@ export const linksGroup = style({
   width: '100%',
   order: 4,
   justifyContent: 'space-between',
+  alignItems: 'baseline',
   marginTop: vars.space.md,
 
   '@media': {
@@ -145,10 +146,6 @@ export const arrowDropdownButton = style({
   border: 'none',
   cursor: 'pointer',
   marginLeft: 0,
-});
-
-globalStyle(`${arrowDropdownButton}[aria-expanded=true] + ${projectsList}`, {
-  padding: '1px',
 });
 
 export const projectItem = style({


### PR DESCRIPTION
## Motivation

#185 - thanks Min!

## Approach

Vertical aligned elements to the baseline and remove the padding of the arrow icon which was causing an offset in the dropdown label. 

![Screen Shot 2022-02-08 at 12 51 13](https://user-images.githubusercontent.com/4451393/152981988-58776fd1-bcab-496e-a202-617715ea32c4.png)


I _think_ it's aligned now, please check. 