### PR TITLE
use `devDependencies` for interactors in tutorial

### DIFF
--- a/src/blog/2022-03-03-backstage-tutorial-plugin-tests-interactors.md
+++ b/src/blog/2022-03-03-backstage-tutorial-plugin-tests-interactors.md
@@ -90,13 +90,13 @@ There's actually only two Interactors-specific settings to consider. First, make
 Next, add the Material UI Interactors to your plugin. You know the drill:
 
 ```bash
-yarn add @interactors/material-ui
+yarn add --dev @interactors/material-ui
 ```
 
 You can [use Interactors with Jest](https://frontside.com/interactors/docs/jest) in this step if you want, but because we'll be using them with Cypress, we need to install specific bindings:
 
 ```bash
-yarn add @interactors/with-cypress
+yarn add --dev @interactors/with-cypress
 ```
 
 ## Assert with Interactors


### PR DESCRIPTION
## Motivation
the `dependencies` of a plugin in `package.json` will be installed into a project whenever the plugin is installed. However, JavaScript used to _test_ the plugin is not necessary for consumers of that plugin. If you use a plugin that is tested with interactors, we don't want to install interactors and all interactors dependencies into the project.

## Approach


This tweaks the tutorial slightly to add the `yarn --dev`  flag to the commands to install `@interactors/material-ui` and `@interactors/with-cypress` That way, they will be added to `devDependencies` instead of `dependencies` and will _not_ be installed into the consumers of a plugin.