### PR TITLE
Add graphgen website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -42,6 +42,12 @@ to = "https://effection.netlify.app/effection/:splat"
 
 [[redirects]]
 force = true
+from = "/graphgen/*"
+status = 200
+to = "https://graphgen.netlify.app/graphgen/:splat"
+
+[[redirects]]
+force = true
 from = "/interactors/html/api"
 status = 301
 to = "/interactors/html/api/index.html"


### PR DESCRIPTION
## Motivation

Graphgen has a new website! We should make it accessible from the main domain.

## Approach

This adds a redirect for the `/graphgen` path to the graphgen website
