### PR TITLE
Proxy to the new graphgen site running on fresh and deno.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -44,7 +44,8 @@ to = "https://effection.netlify.app/effection/:splat"
 force = true
 from = "/graphgen/*"
 status = 200
-to = "https://graphgen.netlify.app/graphgen/:splat"
+to = "https://graphgen.deno.dev/:splat"
+headers = {X-Base = "https://frontside.com/graphgen/" }
 
 [[redirects]]
 force = true


### PR DESCRIPTION
## Motivation

Freshen up the Graphgen documentation

## Approach

Redirect to the Graphgen website, and be sure to set the "base" header accordingly so that it can accommodate it.
