### PR TITLE
Redirect all /platformscript/* traffic to PS website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -49,6 +49,13 @@ headers = {X-Base = "https://frontside.com/graphgen/" }
 
 [[redirects]]
 force = true
+from = "/platformscript/*"
+status = 200
+to = "https://platformscript.deno.dev/:splat"
+headers = {X-Base = "https://frontside.com/platformscript/" }
+
+[[redirects]]
+force = true
 from = "/interactors/html/api"
 status = 301
 to = "/interactors/html/api/index.html"


### PR DESCRIPTION
## Motivation
We have a new platformscript website at https://platformscript.deno.dev


## Approach

redirect everything under the subpath `/platformscript/` to it.

## TODOS

- [x] refactor docs page in ps/www to use `createPage()` which properly injects the base tag.