### PR TITLE
Header based delegation on fresh pages with islands

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -52,7 +52,7 @@ force = true
 from = "/platformscript/*"
 status = 200
 to = "https://platformscript.deno.dev/:splat"
-headers = {X-Base = "https://frontside.com/platformscript/" }
+headers = {X-Base = "https://frontside.com/platformscript/", X-Fresh-Base-Url = "https://frontside.com/platformscript/" }
 
 [[redirects]]
 force = true


### PR DESCRIPTION
## Motivation

When we started delegating to fresh pages that had islands on them, things started breaking. This is because Fresh currently assumes that its server is sitting at the root of a website, and unlike our normal pages, we could not adjust the base with a middleware. As a result, there will have to be some sort of change to Fresh. [It's not clear what form this will take](https://github.com/denoland/fresh/issues/697), but in the meantime, we can use a [patched Fresh](https://github.com/denoland/fresh/compare/main...thefrontside:fresh:render-with-base-url) that will render its assets taking into account the `x-fresh-base-url` header.

## Approach

Pass along the `X-Fresh-Base-Url` header to the delegated subpath.
