### PR TITLE
Update cta success message

### DIFF
--- a/src/components/cta-contact.tsx
+++ b/src/components/cta-contact.tsx
@@ -69,7 +69,7 @@ export default function ContactCTA({
           <strong className={thanksClassName}>Thanks for reaching out!</strong>
           <br />
           <span className={textSm}>
-            We'll get back to you within a business day.
+            Thank you for submitting a request. We will be in touch shortly.
           </span>
         </p>
       )}

--- a/src/components/cta-support.tsx
+++ b/src/components/cta-support.tsx
@@ -69,7 +69,7 @@ export default function ContactCTA({
           <strong className={thanksClassName}>Thanks for reaching out!</strong>
           <br />
           <span className={textSm}>
-            We'll get back to you within a business day.
+            Thank you for submitting a request. We will be in touch shortly.
           </span>
         </p>
       )}


### PR DESCRIPTION
## Motivation
We want to remove any explicit time promises just in case that time frame is not met, most replies happen 24-48 hours, some <24hrs but just in case, we should leave ourselves with some flexibility.

