### PR TITLE
Add PageSense

### DIFF
--- a/nextgen/html/app.html.tsx
+++ b/nextgen/html/app.html.tsx
@@ -31,6 +31,7 @@ export default function* AppHtml(options: Options): Operation<JSX.Element> {
         <link rel="canonical" href={siteURL} />
         <link rel="alternate" href={siteURL} hreflang="en" />
         <link rel="alternate" href={siteURL} hreflang="x-default" />
+        <script src="https://cdn.pagesense.io/js/frontsidesoftware/12a41c994cce49f684b5c690d6e64c74.js"></script>
       </head>
       <body>
         <header class="p-5 lg:max-w-5xl lg: m-auto">


### PR DESCRIPTION
## Motivation
To optimize the workshop page and improve our marketing strategy, we are looking to gain insights into user behavior and page performance. By integrating PageSense, we can see how the workshop page fares in terms of conversion, marketing, and content, and we'll also have the capability to monitor the entire website, allowing us to make data-driven decisions across all pages.

## Approach
- Integrate a CRO - website and conversion rate optimization tool like PageSense
- Integrate Page sense
