### PR TITLE
Make workshop header layout like main site header.

### DIFF
--- a/nextgen/html/advance-backstage-plugin-development.html.tsx
+++ b/nextgen/html/advance-backstage-plugin-development.html.tsx
@@ -30,7 +30,7 @@ export function* AdvancedBackstagePluginDevelopmentHtml(): Operation<
             <span class="text-blue-secondary">Plugins!</span>
           </h1>
           <p class="pr-8 mt-5 mb-10 tracking-wide text-xl text-blue-primary prose">
-             Learn from hands-on workshop derived from our work with large enterprise organizations. This isn't mere theory—it's actionable expertise. Join a workshop infused with best practices, insights, and advanced engineering.
+             Learn from a hands-on workshop derived from our experience with large enterprises. This isn't theory—it's actionable expertise. Join a workshop loaded with best practices, insights, and advanced engineering.
           </p>
           <a
             data-tf-popup="fNHxMLVS"

--- a/nextgen/html/app.html.tsx
+++ b/nextgen/html/app.html.tsx
@@ -50,30 +50,17 @@ export default function* AppHtml(options: Options): Operation<JSX.Element> {
         {PageSenseScriptTag}
       </head>
       <body>
-        <header class="p-5 lg:max-w-5xl lg: m-auto grid grid-rows-2 md:grid-rows-1">
-          <nav aria-label="Site Nav">
-            <menu class="flex justify-between">
-              <a href="/">
-                <img
-                  width={137}
-                  height={34.172}
-                  src={logoURL}
-                  alt="Frontside Logo"
-                />
-              </a>
-              <a
-                class="btn-contact uppercase rounded-lg font-bold py-2 md:py-1.5 px-2 md:px-2.5 bg-contain text-white text-sm md:text-base"
-                href="/contact"
-              >
-                Contact
-              </a>
-            </menu>
-          </nav>
-          <nav
-            class="mt-14 font-bold leading-5 tracking-wide text-blue-primary text-xs lg:text-sm"
-            arial-label="Home Nav"
-          >
-            <menu class="flex justify-between">
+        <header class="p-5 max-w-screen-sm lg:max-w-screen-2xl m-auto lg:p-12">
+          <nav class="flex flex-wrap items-center justify-end lg:gap-x-10" aria-label="Site Nav">
+            <a class="order-1 mr-auto" href="/">
+              <img
+                width={137}
+                height={34.172}
+                src={logoURL}
+                alt="Frontside Logo"
+              />
+            </a>
+            <menu class="w-full mt-14 font-bold leading-5 tracking-wide text-blue-primary text-sm flex justify-between order-3 lg:order-2 lg:mt-0 lg:w-auto lg:gap-x-12">
               <li>
                 <a href="/consulting">DX Consulting</a>
               </li>
@@ -87,6 +74,12 @@ export default function* AppHtml(options: Options): Operation<JSX.Element> {
                 <a href="/blog">Blog</a>
               </li>
             </menu>
+            <a
+              class="btn-contact uppercase rounded-lg font-bold py-2 md:py-1.5 px-2 md:px-2.5 bg-contain text-white text-sm md:text-base order-2"
+              href="/contact"
+            >
+              Contact
+            </a>
           </nav>
         </header>
         <main>


### PR DESCRIPTION
## Motivation

The workshop header needs to match the rest of the site, otherwise transition between the two will be janky.

## Approach

This converts the layout to a flexbox just as it is now.

### Possible Drawbacks or Risks

There is a slight mismatch with the tailwind system and the hand-rolled vanilla extract system we had before. For example, our existing site has its first screen breakpoint at `999px`. Tailwind has queries set up for 640px (small) 768px (medium) and 1024px (large), so this uses the closest tailwind breakpoint at 1024px. 

There are a lot of instances where there are slight discrepancies between what we chose when we originally styled the site and what tailwind has as a preset. If we want resolve these discrepancies, I think the best approach would be to go back and adjust the _existing_ site to use the tailwind breakpoints and font sizes, etc.... rather than bend tailwind to our existing completely bespoke scheme.
 
## Screenshots


See preview at https://frontside--cl-style-workshop-header-t.deno.dev/