### PR TITLE
🐛Fix bogus toggling of the OSS projects

### DIFF
--- a/nextgen/components/project-select.tsx
+++ b/nextgen/components/project-select.tsx
@@ -12,6 +12,9 @@ export function ProjectSelect() {
         #${toggleId}:checked ~ label#${openerId} > aside {
           display: none;
         }
+        #${toggleId}:checked ~ label#${closerId} {
+          display: none;
+        }
         #${toggleId} ~ label#${closerId} {
           display: block;
         }
@@ -63,7 +66,7 @@ export function ProjectSelect() {
 
       <label
         id={closerId}
-        class="absolute w-full h-full inset-0 z-50 hidden"
+        class="absolute w-screen h-screen inset-0 z-50 hidden"
         for={toggleId}
       />
     </>


### PR DESCRIPTION
## Motivation

The glass pane that closed the toggle was covering the entire site, and always on. This means that nobody could sign up because the button was covered by the select box closer 😬

## Approach
This makes sure that the closer is only active when the context menu is _showing_, and never at any other time.
