### PR TITLE
🐞Fix the interactors URL

### DIFF
--- a/legacy/src/blog/2021-08-04-interactors-design-systems.md
+++ b/legacy/src/blog/2021-08-04-interactors-design-systems.md
@@ -33,7 +33,7 @@ There's a well-trod design pattern for fixing this problem: [page objects](https
 
 ## Introducing Interactors
 
-At Frontside, we've built [Interactors](https://frontside.com/bigtest/interactors) (`@interactors/html`), a library inspired by page objects that helps teams structure, share, and reuse their UI testing practices.
+At Frontside, we've built [Interactors](https://frontside.com/interactors) (`@interactors/html`), a library inspired by page objects that helps teams structure, share, and reuse their UI testing practices.
 
 Interactors evolve the idea of a page object. Modern applications are usually arranged into composable components, and the "page" is no longer the dominant unit of organization. An Interactor is similarly composable, and can abstract any level of object in the DOM hierarchy.
 


### PR DESCRIPTION
## Motivation

The actual interactors URL is changed to just `/interactors`, not `/bigtest/interactors`
