### PR TITLE
Proxy the Effection and Graphgen sites directly

### DIFF
--- a/legacy/netlify.toml
+++ b/legacy/netlify.toml
@@ -24,20 +24,6 @@ to = "https://bigtest.netlify.app/bigtest/:splat"
 
 [[redirects]]
 force = true
-from = "/effection/*"
-status = 200
-to = "https://effection.deno.dev/:splat"
-headers = { X-Base-Url = "https://frontside.com/effection" }
-
-[[redirects]]
-force = true
-from = "/graphgen/*"
-status = 200
-to = "https://graphgen.deno.dev/:splat"
-headers = {X-Base = "https://frontside.com/graphgen/" }
-
-[[redirects]]
-force = true
 from = "/platformscript/*"
 status = 200
 to = "https://platformscript.deno.dev/:splat"

--- a/sitemap/proxy.ts
+++ b/sitemap/proxy.ts
@@ -1,0 +1,30 @@
+import { ServeHandler } from "../lib/types.ts";
+import { expect } from "effection";
+
+export interface ProxyOptions {
+  website: string;
+  prefix: string;
+}
+
+export function proxy(options: ProxyOptions): ServeHandler {
+  return function* handler({ request }) {
+    let website = new URL(options.website);
+    let target = new URL(request.url);
+    let prefix = new RegExp(`^\/${options.prefix}\/?`)
+    target.pathname = target.pathname.replace(prefix, "/");
+    target.hostname = website.hostname;
+    target.port = website.port;
+    target.protocol = website.protocol;
+
+    let base = new URL(`/${options.prefix}`, request.url);
+
+    let response = yield* expect(fetch(target, {
+      headers: {
+        ...request.headers,
+        "X-Base-Url": base.toString(),
+      }
+    }));
+
+    return response;
+  }
+}

--- a/sitemap/proxy.ts
+++ b/sitemap/proxy.ts
@@ -19,6 +19,7 @@ export function proxy(options: ProxyOptions): ServeHandler {
     let base = new URL(`/${options.prefix}`, request.url);
 
     let response = yield* expect(fetch(target, {
+      redirect: "manual",
       headers: {
         ...request.headers,
         "X-Base-Url": base.toString(),

--- a/sitemap/sitemap.ts
+++ b/sitemap/sitemap.ts
@@ -6,6 +6,8 @@ import { GatsbyWebsite } from "../legacy/gatsby-website.ts";
 
 import { AdvancedBackstagePluginDevelopmentHtml, AppHtml } from "../html.ts";
 
+import { proxy } from "./proxy.ts";
+
 export default () =>
   serve({
     "/workshops/advanced-backstage-plugin-development": html.get(() =>
@@ -21,5 +23,13 @@ export default () =>
         AdvancedBackstagePluginDevelopmentHtml(),
       )
     ),
+    "/effection(.*)": proxy({
+      prefix: "effection",
+      website: "https://effection.deno.dev",
+    }),
+    "/graphgen(.*)": proxy({
+      prefix: "graphgen",
+      website: "https://graphgen.deno.dev",
+    }),
     "(.*)": GatsbyWebsite,
   });


### PR DESCRIPTION
## Motivation

Cut Netlify out of the loop.

Right now, when someone asks for https://frontside.com/effection

The request proceeds from

1. frontside.deno.com
2. frontside.netlify.app
3. effection.deno.com

And the response comes back via

3. effection.deno.com
2. frontside.netlify.app
1. frontside.deno.com

Eventually we want to be able to serve all the code directly from frontside.deno.com, and the first stem is to cut out netlify completely from that round trip.

## Approach

This removes the netilfy redirects for graphgen, and effection, and adds them directly to the frontside.com site.

## Preview

https://frontside--directly-redirect-to-effec.deno.dev/graphgen
