### PR TITLE
🔥Get rid of obsolete `main.ts`

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,1 +1,0 @@
-import "./main.tsx";


### PR DESCRIPTION
## Motivation

You can put TSX directly into your routes now, so the convention is to use `.tsx` The production branch on deno.com is now pointing to `main.tsx` so there is no reason to keep this entry point around.

## Approach

Torch it!
