### PR TITLE
✨ Proxy the Interactors website directly.

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -19,6 +19,6 @@
   "imports": {
     "effection": "https://deno.land/x/effection@3.0.0-beta.2/mod.ts",
     "revolution": "https://deno.land/x/revolution@0.3.1/mod.ts",
-    "revolution/jsx-runtime": "https://deno.land/x/revolution@0.3.1/jsx-runtime.ts",
+    "revolution/jsx-runtime": "https://deno.land/x/revolution@0.3.1/jsx-runtime.ts"
   }
 }

--- a/main.tsx
+++ b/main.tsx
@@ -30,6 +30,7 @@ await main(function* () {
       route("/effection(.*)", proxyRoute(proxies.effection)),
       route("/graphgen(.*)", proxyRoute(proxies.graphgen)),
       route("/assets(.*)", assetsRoute("assets")),
+      route("/interactors(.*)", proxyRoute(proxies.interactors)),
       proxyRoute(proxies.legacy),
     ],
 
@@ -51,6 +52,11 @@ function proxySites() {
     effection: {
       prefix: "effection",
       website: Deno.env.get("EFFECTION_URL") ?? "https://effection.deno.dev",
+    },
+    interactors: {
+      prefix: "interactors",
+      root: "interactors/",
+      website: Deno.env.get("INTERACTORS_URL") ?? "https://interactors.deno.dev"
     },
     graphgen: {
       prefix: "graphgen",

--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -1,17 +1,21 @@
 import type { HTTPMiddleware } from "revolution";
-import { call } from "effection";
+import { call, Operation } from "effection";
 
 export interface ProxyRouteOptions {
   website: string;
   prefix: string;
+  root?: string;
 }
 
 export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
-  return function* proxy(request) {
+  return function* proxy(request): Operation<Response> {
     let website = new URL(options.website);
+
     let target = new URL(request.url);
+
     let prefix = new RegExp(`^\/${options.prefix}\/?`);
-    target.pathname = target.pathname.replace(prefix, "/");
+    target.pathname = target.pathname.replace(prefix, options.root ?? "/");
+
     target.hostname = website.hostname;
     target.port = website.port;
     target.protocol = website.protocol;
@@ -29,6 +33,25 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
       redirect: "manual",
       headers,
     }));
+
+    if (response.status === 301) {
+      let location = response.headers.get("location");
+      if (location?.startsWith(String(website))) {
+        let headers: Record<string, string> = {};
+        for (let [key, value] of request.headers.entries()) {
+          headers[key] = value;
+        }
+
+        let url = new URL(request.url);
+        headers.location = location.replace(target.origin, url.origin);
+
+        response = new Response(null, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      }
+    }
 
     return response;
   };


### PR DESCRIPTION
## Motivation

The Interactors website had been proxied by netlify in our Gatsby legacy site to interactors site also running on netlify. We want to cut out the middleman and serve the interactors site directly. This will not only be faster in the short term. It will also set us up long-term to use sitemaps to build the entire frontside.com statically.

```
// before
Deno(fs.com) -> Netlify(Gatsby) -> Netlify(Docusaurus)

// after
Deno(fs.com) -> Deno(Docusaurus)
```

## Approach

This enhances proxy routes to take on serving static docusaurus sites. It does two things. 1) It accepts a `root` parameter which gives the root path on the proxy site that we start serving from. 2) we enhance the proxy generally so that if it receives a redirect to itself, then it will also proxy the redirect rather than go to the source site. In other words suppose we make this request.

```
GET https://localhost:8005/interactors
```

which delegates to 

```
https://interactors.deno.dev/interactors
```
But that response with a redirect:

```
301: Moved Permanently
Location: https://interactors.deno.dev/interactors/home/
```

We don't want the browser to redirect there. Instead, we want it to redirect back to itself:

```
301: Moved Permanently
Location: https:/localhost:8005/interactors/home/
```