### PR TITLE
♻️ Simplify the proxying scheme.

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,6 +5,9 @@
     "npm:@twind/preset-tailwind@1.1.4": "1.1.4_@twind+core@1.1.3",
     "npm:@twind/preset-typography@1.0.7": "1.0.7_@twind+core@1.1.3",
     "npm:@types/hast@3": "3.0.4",
+    "npm:hast-util-from-html@*": "2.0.3",
+    "npm:hast-util-select@*": "6.0.2",
+    "npm:hast-util-to-html@*": "9.0.0",
     "npm:hast-util-to-html@9.0.0": "9.0.0"
   },
   "npm": {
@@ -44,6 +47,12 @@
     "@ungap/structured-clone@1.2.0": {
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
+    "bcp-47-match@2.0.3": {
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="
+    },
+    "boolbase@1.0.0": {
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "ccount@2.0.1": {
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
     },
@@ -55,6 +64,9 @@
     },
     "comma-separated-tokens@2.0.3": {
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
+    },
+    "css-selector-parser@3.0.5": {
+      "integrity": "sha512-3itoDFbKUNx1eKmVpYMFyqKX04Ww9osZ+dLgrk6GEv6KMVeXUhUnp4I5X+evw+u3ZxVU6RFXSSRxlTeMh8bA+g=="
     },
     "csstype@3.1.3": {
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
@@ -68,8 +80,22 @@
         "dequal"
       ]
     },
+    "direction@2.0.1": {
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="
+    },
     "entities@4.5.0": {
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+    },
+    "hast-util-from-html@2.0.3": {
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "dependencies": [
+        "@types/hast",
+        "devlop",
+        "hast-util-from-parse5",
+        "parse5",
+        "vfile",
+        "vfile-message"
+      ]
     },
     "hast-util-from-parse5@8.0.1": {
       "integrity": "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==",
@@ -82,6 +108,12 @@
         "vfile",
         "vfile-location",
         "web-namespaces"
+      ]
+    },
+    "hast-util-has-property@3.0.0": {
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "dependencies": [
+        "@types/hast"
       ]
     },
     "hast-util-parse-selector@4.0.0": {
@@ -105,6 +137,27 @@
         "unist-util-visit",
         "vfile",
         "web-namespaces",
+        "zwitch"
+      ]
+    },
+    "hast-util-select@6.0.2": {
+      "integrity": "sha512-hT/SD/d/Meu+iobvgkffo1QecV8WeKWxwsNMzcTJsKw1cKTQKSR/7ArJeURLNJF9HDjp9nVoORyNNJxrvBye8Q==",
+      "dependencies": [
+        "@types/hast",
+        "@types/unist",
+        "bcp-47-match",
+        "comma-separated-tokens",
+        "css-selector-parser",
+        "devlop",
+        "direction",
+        "hast-util-has-property",
+        "hast-util-to-string",
+        "hast-util-whitespace",
+        "not",
+        "nth-check",
+        "property-information",
+        "space-separated-tokens",
+        "unist-util-visit",
         "zwitch"
       ]
     },
@@ -135,6 +188,12 @@
         "space-separated-tokens",
         "web-namespaces",
         "zwitch"
+      ]
+    },
+    "hast-util-to-string@3.0.1": {
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "dependencies": [
+        "@types/hast"
       ]
     },
     "hast-util-whitespace@3.0.0": {
@@ -193,6 +252,15 @@
     },
     "micromark-util-types@2.0.0": {
       "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+    },
+    "not@0.1.0": {
+      "integrity": "sha512-5PDmaAsVfnWUgTUbJ3ERwn7u79Z0dYxN9ErxCpVJJqe2RK0PJ3z+iFUxuqjwtlDDegXvtWoxD/3Fzxox7tFGWA=="
+    },
+    "nth-check@2.1.1": {
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": [
+        "boolbase"
+      ]
     },
     "parse5@7.1.2": {
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",

--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -1,5 +1,9 @@
 import type { HTTPMiddleware } from "revolution";
 import { call, Operation } from "effection";
+import { fromHtml } from "npm:hast-util-from-html";
+import { toHtml } from "npm:hast-util-to-html";
+import { selectAll } from "npm:hast-util-select";
+import { posixNormalize } from "https://deno.land/std@0.201.0/path/_normalize.ts";
 
 export interface ProxyRouteOptions {
   website: string;
@@ -22,28 +26,27 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
 
     let base = new URL(`/${options.prefix}`, request.url);
 
-    let headers: Record<string, string> = {
-      "X-Base-Url": base.toString(),
-    };
-    for (let [key, value] of request.headers.entries()) {
-      headers[key] = value;
-    }
-
-    let response = yield* call(fetch(target, {
-      redirect: "manual",
-      headers,
-    }));
+    let response = yield* call(() =>
+      fetch(target, {
+        redirect: "manual",
+      })
+    );
 
     if (response.status === 301) {
       let location = response.headers.get("location");
       if (location?.startsWith(String(website))) {
         let headers: Record<string, string> = {};
-        for (let [key, value] of request.headers.entries()) {
+        for (let [key, value] of response.headers.entries()) {
           headers[key] = value;
         }
 
         let url = new URL(request.url);
-        headers.location = location.replace(target.origin, url.origin);
+
+        let loc = new URL(location);
+        if (!options.root) {
+          loc.pathname = `${options.prefix}${loc.pathname}`;
+        }
+        headers.location = loc.toString().replace(target.origin, url.origin);
 
         response = new Response(null, {
           status: response.status,
@@ -51,6 +54,36 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
           headers,
         });
       }
+    } else if (
+      response.headers.get("Content-Type")?.match(/html/) && !options.root
+    ) {
+      let body = yield* call(() => response.text());
+      let tree = fromHtml(body);
+
+      let elements = selectAll('[href^="/"],[src^="/"]', tree);
+
+      for (let element of elements) {
+        let properties = element.properties!;
+
+        if (properties.href) {
+          properties.href = posixNormalize(
+            `${base.pathname}${properties.href}`,
+          );
+        }
+        if (properties.src) {
+          properties.src = posixNormalize(`${base.pathname}${properties.src}`);
+        }
+      }
+      let headers: Record<string, string> = {};
+      for (let [key, value] of response.headers.entries()) {
+        headers[key] = value;
+      }
+
+      response = new Response(toHtml(tree), {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      });
     }
 
     return response;


### PR DESCRIPTION
## Motivation

Our proxy scheme was based on the idea that the proxy path is passed to the proxied website vias the `X-Base-Url` header. That way, the proxy site can generate itself with the correct based urls.

So, for example if the site linked to:

`<a href="/images/file.gif" />`

Then it would generate the html:

`<a href="/basepath/images/file.gif" />`

With the same applying to links, images, stylesheets, scripts etc.....

The idea was that this would save computation since the HTML could be "rebased" at the source. That way we wouldn't have to read the entire stream, parse it as html, re-write the links, and then re-serialize it.

The onyl problem is that lots of links get generated from a lot of different contexts that we may or may not be able to control depending on which frameworks we use. In the case where we control the framework, we can access those places and generate the urls correctly.

However, for things like docusaurus and fresh, it ain't so easy.

## Approach

This side steps all that, and just fetches the upstream website as-is, parses the HTML, and rewrites the links in the proxy itself. While nominally more expensive because it involves a parse and reserialization of the HTML, it is much less complex, and requires ZERO changes to the upstream site. It serves every request the way it would always do it.

In summary, we're moving like this
https://github.com/thefrontside/effection/blob/v3/www/plugins/rebase.ts#L39-L53 over onto the consumer. It's safer, and just much more robust.

Since we're going to be capturing a static snapshot of the website anyway, it doesn't matter if the dynamic version is a bit less efficient. And even in the case where we do care, it would be much eaiser just to put a proper HTTP caching mechanism in place.

