### PR TITLE
✨ Handle all redirect codes for sub sites

### DIFF
--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -32,7 +32,7 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
       })
     );
 
-    if (response.status === 301) {
+    if ([301, 302, 307, 308].includes(response.status)) {
       let location = response.headers.get("location");
       if (location?.startsWith(String(website))) {
         let headers: Record<string, string> = {};


### PR DESCRIPTION
## Motivation

When we are proxying a website, and that site sends a redirect, we need to redirect through ourselves. This was only happening on a 301, but there are actually all kinds of redirect codes that have to be handled. As it turns out, fresh framework which Graphgen was using uses 302 for its redirects.

## Approve
This goes ahead and adds 302,307,308 to the list, so that we pick up all current and future redirects.
