### PR TITLE
Changed the URL to effection-www website

### DIFF
--- a/main.tsx
+++ b/main.tsx
@@ -53,7 +53,7 @@ function proxySites() {
   return {
     effection: {
       prefix: "effection",
-      website: Deno.env.get("EFFECTION_URL") ?? "https://effection.deno.dev",
+      website: Deno.env.get("EFFECTION_URL") ?? "https://effection-www.deno.dev",
     },
     interactors: {
       prefix: "interactors",


### PR DESCRIPTION
## Motivation

Lots of work went into the new effection website with API reference and effection contrib. Let's start using it. 

Here is a preview link to the Effection section https://frontside-2dmjz1vzdtp1.deno.dev/effection/

## Approach

Changed the URL to point to the new project url. 

