### PR TITLE
Rewrite URL in redirect

### DIFF
--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -83,7 +83,7 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
         }
         if (properties.content) {
           if (typeof properties.content === "string") {
-            const parts = properties.content.match(/\d;\s?url=(.*)/);
+            const parts = properties.content.match(/\d;\s*url=(.*)/);
             if (parts) {
               const [, url] = parts;
               properties.content = properties.content.replace(

--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -60,7 +60,10 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
       let body = yield* call(() => response.text());
       let tree = fromHtml(body);
 
-      let elements = selectAll('[href^="/"],[src^="/"],form[action]', tree);
+      let elements = selectAll(
+        '[href^="/"],[src^="/"],form[action],[http-equiv="refresh"][content]',
+        tree,
+      );
 
       for (let element of elements) {
         let properties = element.properties!;
@@ -77,6 +80,18 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
           properties.action = posixNormalize(
             `${base.pathname}${properties.action}`,
           );
+        }
+        if (properties.content) {
+          if (typeof properties.content === "string") {
+            const parts = properties.content.match(/\d;\s?url=(.*)/);
+            if (parts) {
+              const [, url] = parts;
+              properties.content = properties.content.replace(
+                url,
+                posixNormalize(`${base.pathname}${url}`),
+              );
+            }
+          }
         }
       }
       let headers: Record<string, string> = {};


### PR DESCRIPTION
## Motivation

docs redirect is broken because proxyRoute is not rewriting `http-equiv="refresh"`

## Approach

Parse out the URL and replace it with one that includes the prefix. 
