### PR TITLE
✨ Inject plausible analytics into proxied sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Local Netlify folder
 .netlify
 legacy/node_modules
+legacy/.cache
+legacy/node_modules
+legacy/public

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
-    "dev": "deno -A jsr:@effection-contrib/watch deno run -A main.tsx --dev"
+    "dev": "deno -A jsr:@effection-contrib/watch deno run -A main.tsx --dev",
+    "start": "deno -A main.tsx",
   },
   "lint": {
     "rules": {

--- a/deno.json
+++ b/deno.json
@@ -17,7 +17,8 @@
     "jsxImportSource": "revolution"
   },
   "imports": {
-    "effection": "https://deno.land/x/effection@3.0.0-beta.2/mod.ts",
+    "effection": "jsr:@effection/effection@3.2.0",
+    "hast": "npm:hast@^1.0.0",
     "revolution": "https://deno.land/x/revolution@0.6.1/mod.ts",
     "revolution/jsx-runtime": "https://deno.land/x/revolution@0.6.1/jsx-runtime.ts"
   }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run -A lib/watch.ts blog components lib assets routes plugins -- deno run -A main.tsx --dev"
+    "dev": "deno -A jsr:@effection-contrib/watch deno run -A main.tsx --dev"
   },
   "lint": {
     "rules": {

--- a/deno.lock
+++ b/deno.lock
@@ -1,12 +1,16 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@effection/effection@3.2.0": "3.2.0",
+    "jsr:@frontside/continuation@0.1.6": "0.1.6",
+    "jsr:@std/assert@1.0.10": "1.0.10",
     "jsr:@std/cli@^1.0.6": "1.0.7",
     "jsr:@std/encoding@^1.0.5": "1.0.5",
     "jsr:@std/fmt@^1.0.3": "1.0.3",
     "jsr:@std/fs@*": "1.0.5",
     "jsr:@std/html@^1.0.3": "1.0.3",
     "jsr:@std/http@*": "1.0.11",
+    "jsr:@std/internal@^1.0.5": "1.0.5",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.4": "1.0.4",
     "jsr:@std/path@^1.0.7": "1.0.8",
@@ -22,6 +26,7 @@
     "npm:hast-util-select@*": "6.0.3",
     "npm:hast-util-to-html@*": "9.0.0",
     "npm:hast-util-to-html@9.0.0": "9.0.0",
+    "npm:hast@1": "1.0.0",
     "npm:rehype-prism-plus@1.5.1": "1.5.1",
     "npm:rehype-slug@5.1.0": "5.1.0",
     "npm:remark-frontmatter@5.0.0": "5.0.0",
@@ -29,6 +34,22 @@
     "npm:remark-mdx-frontmatter@5.0.0": "5.0.0"
   },
   "jsr": {
+    "@effection/effection@3.2.0": {
+      "integrity": "28865ac2be00b79236fd23e7c4803884921eb8d5637f57e3e12c0abae7b23d63",
+      "dependencies": [
+        "jsr:@frontside/continuation",
+        "jsr:@std/assert"
+      ]
+    },
+    "@frontside/continuation@0.1.6": {
+      "integrity": "f36a3b9ccdf49f0b15778a5e11a37d91bb097f67522f17ca5fbd668560b31c17"
+    },
+    "@std/assert@1.0.10": {
+      "integrity": "59b5cbac5bd55459a19045d95cc7c2ff787b4f8527c0dd195078ff6f9481fbb3",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
     "@std/cli@1.0.7": {
       "integrity": "98359df9df586a69015ba570305183b0cb9e7d53c05ea2016ef9a3e77e82c7cd"
     },
@@ -59,6 +80,9 @@
         "jsr:@std/path@^1.0.8",
         "jsr:@std/streams"
       ]
+    },
+    "@std/internal@1.0.5": {
+      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
     },
     "@std/media-types@1.1.0": {
       "integrity": "c9d093f0c05c3512932b330e3cc1fe1d627b301db33a4c2c2185c02471d6eaa4"
@@ -535,6 +559,9 @@
       "dependencies": [
         "@types/hast@3.0.4"
       ]
+    },
+    "hast@1.0.0": {
+      "integrity": "sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA=="
     },
     "hastscript@7.2.0": {
       "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
@@ -1812,5 +1839,11 @@
     "https://deno.land/x/revolution@0.6.1/lib/sse.ts": "b7bdcb9a606c262a7e9113e03b4a1bcaac8c17d18993f42d4f99127a5bed78de",
     "https://deno.land/x/revolution@0.6.1/lib/types.ts": "2f32cbc673d496b5a37e5b9ff829577866d66a19b993ed59840b92700861d237",
     "https://deno.land/x/revolution@0.6.1/mod.ts": "ffae461c16d4a1bf24c2179582ab8d5c81ad0df61e4ae2fba51ef5e5bdf90345"
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@effection/effection@3.2.0",
+      "npm:hast@1"
+    ]
   }
 }

--- a/main.tsx
+++ b/main.tsx
@@ -53,10 +53,10 @@ await main(function* (args) {
       etagPlugin(),
       currentRequestPlugin(),
       twindPlugin({ config }),
-      plausiblePlugin({ enabled: !dev }),
-      umamiPlugin({
+      yield* plausiblePlugin({ enabled: !dev }),
+      yield* umamiPlugin({
         enabled: !dev,
-        umamiWebsiteID: Deno.env.get("UMAMI_WEBSITE_ID"),
+        websiteID: Deno.env.get("UMAMI_WEBSITE_ID"),
       }),
     ],
   });

--- a/plugins/plausible.ts
+++ b/plugins/plausible.ts
@@ -1,33 +1,45 @@
-import { RevolutionPlugin } from "revolution";
+import { HASTHtmlNode, RevolutionPlugin } from "revolution";
 import { select } from "npm:hast-util-select";
+import { createContext, type Operation } from "effection";
+import { type Root } from "hast";
 
 export interface PlausibleOptions {
   enabled: boolean;
 }
 
-export function plausiblePlugin(options: PlausibleOptions): RevolutionPlugin {
+const PlausibleContext = createContext<PlausibleOptions>("plausible");
+
+export function* plausiblePlugin(
+  options: PlausibleOptions,
+): Operation<RevolutionPlugin> {
+  yield* PlausibleContext.set(options);
+
   return {
     *html(request, next) {
       let html = yield* next(request);
 
-      if (!options.enabled) {
-        return html;
-      }
-
-      let head = select("head", html);
-
-      head?.children.push({
-        type: "element",
-        tagName: "script",
-        properties: {
-          src: "https://plausible.io/js/script.js",
-          defer: true,
-          "data-domain": "frontside.com",
-        },
-        children: [],
-      });
-
-      return html;
+      return yield* injectPlausible(html);
     },
   };
+}
+
+export function* injectPlausible(html: Root): Operation<HASTHtmlNode> {
+  let { enabled } = yield* PlausibleContext.expect();
+
+  if (enabled) {
+    let head = select("head", html);
+
+    head?.children.push({
+      type: "element",
+      tagName: "script",
+      properties: {
+        src: "https://plausible.io/js/script.js",
+        defer: true,
+        "data-domain": "frontside.com",
+      },
+      children: [],
+    });
+  }
+
+  return html;
 }

--- a/plugins/umami.ts
+++ b/plugins/umami.ts
@@ -13,7 +13,7 @@ const UmamiContext = createContext<Required<UmamiOptions>>("umami");
 export function* umamiPlugin(
   options: UmamiOptions,
 ): Operation<RevolutionPlugin> {
-  if (!options.websiteID) {
+  if (options.enabled && !options.websiteID) {
     throw new Error(
       "UmamiPlugin: 'websiteId' is required but was not provided. Please pass it in as an option.",
     );

--- a/plugins/umami.ts
+++ b/plugins/umami.ts
@@ -1,39 +1,52 @@
-import { RevolutionPlugin } from "revolution";
+import { HASTHtmlNode, RevolutionPlugin } from "revolution";
 import { select } from "npm:hast-util-select";
+import { createContext, type Operation } from "effection";
+import type { Root } from "hast";
 
 export interface UmamiOptions {
   enabled: boolean;
-  umamiWebsiteID?: string;
+  websiteID?: string;
 }
 
-export function umamiPlugin(options: UmamiOptions): RevolutionPlugin {
-  if (!options.umamiWebsiteID) {
+const UmamiContext = createContext<Required<UmamiOptions>>("umami");
+
+export function* umamiPlugin(
+  options: UmamiOptions,
+): Operation<RevolutionPlugin> {
+  if (!options.websiteID) {
     throw new Error(
       "UmamiPlugin: 'websiteId' is required but was not provided. Please pass it in as an option.",
     );
   }
+
+  yield* UmamiContext.set(options as Required<UmamiOptions>);
+
   return {
     *html(request, next) {
       let html = yield* next(request);
 
-      if (!options.enabled) {
-        return html;
-      }
-
-      let head = select("head", html);
-
-      head?.children.push({
-        type: "element",
-        tagName: "script",
-        properties: {
-          src: "https://cloud.umami.is/script.js",
-          defer: true,
-          "data-website-id": options.umamiWebsiteID,
-        },
-        children: [],
-      });
-
-      return html;
+      return yield* injectUmami(html);
     },
   };
+}
+
+export function* injectUmami(html: Root): Operation<HASTHtmlNode> {
+  let head = select("head", html);
+
+  let { enabled, websiteID } = yield* UmamiContext.expect();
+
+  if (enabled) {
+    head?.children.push({
+      type: "element",
+      tagName: "script",
+      properties: {
+        src: "https://cloud.umami.is/script.js",
+        defer: true,
+        "data-website-id": websiteID,
+      },
+      children: [],
+    });
+  }
+
+  return html;
 }

--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -4,6 +4,8 @@ import { fromHtml } from "npm:hast-util-from-html";
 import { toHtml } from "npm:hast-util-to-html";
 import { selectAll } from "npm:hast-util-select";
 import { posixNormalize } from "https://deno.land/std@0.201.0/path/_normalize.ts";
+import { injectPlausible } from "../plugins/plausible.ts";
+import { injectUmami } from "../plugins/umami.ts";
 
 export interface ProxyRouteOptions {
   website: string;
@@ -59,6 +61,9 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
     ) {
       let body = yield* call(() => response.text());
       let tree = fromHtml(body);
+
+      yield* injectPlausible(tree);
+      yield* injectUmami(tree);
 
       let elements = selectAll(
         '[href^="/"],[src^="/"],form[action],[http-equiv="refresh"][content]',


### PR DESCRIPTION
## Motivation

Our site is a proxy for all our different subsites. However, we are not collecting analytics for them.

## Approach

This makes the plugins export helper functions that allow for the injection of their respective tags into any `html` tree. Then, we can use them inside the proxy, not just the middleware stack.
