### PR TITLE
Add Matomo plugin for anyaltics assessment

### DIFF
--- a/main.tsx
+++ b/main.tsx
@@ -21,6 +21,7 @@ import { blogTagRoute } from "./routes/blog-tag-route.tsx";
 import { initBlog } from "./blog/blog.ts";
 import { plausiblePlugin } from "./plugins/plausible.ts";
 import { umamiPlugin } from "./plugins/umami.ts";
+import { matomoPlugin } from "./plugins/matomo.ts";
 
 await main(function* (args) {
   let dev = !!args.includes("--dev");
@@ -58,6 +59,7 @@ await main(function* (args) {
         enabled: !dev,
         websiteID: Deno.env.get("UMAMI_WEBSITE_ID"),
       }),
+      yield* matomoPlugin({ enabled: !dev }),
     ],
   });
 

--- a/plugins/matomo.ts
+++ b/plugins/matomo.ts
@@ -1,0 +1,55 @@
+import { HASTHtmlNode, RevolutionPlugin } from "revolution";
+import { select } from "npm:hast-util-select";
+import { createContext, type Operation } from "effection";
+import { type Root } from "hast";
+
+export interface MatomoOptions {
+  enabled: boolean;
+}
+
+const MatomoContext = createContext<MatomoOptions>("Matomo");
+
+export function* MatomoPlugin(
+  options: MatomoOptions,
+): Operation<RevolutionPlugin> {
+  yield* MatomoContext.set(options);
+
+  return {
+    *html(request, next) {
+      let html = yield* next(request);
+
+      return yield* injectMatomo(html);
+    },
+  };
+}
+
+export function* injectMatomo(html: Root): Operation<HASTHtmlNode> {
+  let { enabled } = yield* MatomoContext.expect();
+
+  if (enabled) {
+    let head = select("head", html);
+
+    head?.children.push({
+      type: "element",
+      tagName: "script",
+      properties: {
+        defer: true,
+      },
+      children: [
+        {
+          type: "text",
+          value: `
+           var _mtm = window._mtm = window._mtm || [];
+           _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+           (function() {
+             var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+             g.async=true; g.src='https://cdn.matomo.cloud/frontside.matomo.cloud/container_ORAOYPKO.js'; s.parentNode.insertBefore(g,s);
+           })();
+          `,
+        },
+      ],
+    });
+  }
+
+  return html;
+}

--- a/plugins/matomo.ts
+++ b/plugins/matomo.ts
@@ -9,7 +9,7 @@ export interface MatomoOptions {
 
 const MatomoContext = createContext<MatomoOptions>("Matomo");
 
-export function* MatomoPlugin(
+export function* matomoPlugin(
   options: MatomoOptions,
 ): Operation<RevolutionPlugin> {
   yield* MatomoContext.set(options);

--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -6,6 +6,7 @@ import { selectAll } from "npm:hast-util-select";
 import { posixNormalize } from "https://deno.land/std@0.201.0/path/_normalize.ts";
 import { injectPlausible } from "../plugins/plausible.ts";
 import { injectUmami } from "../plugins/umami.ts";
+import { injectMatomo } from "../plugins/matomo.ts";
 
 export interface ProxyRouteOptions {
   website: string;
@@ -64,6 +65,7 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
 
       yield* injectPlausible(tree);
       yield* injectUmami(tree);
+      yield* injectMatomo(tree);
 
       let elements = selectAll(
         '[href^="/"],[src^="/"],form[action],[http-equiv="refresh"][content]',


### PR DESCRIPTION
## Motivation
We need accurate website analytics for the website and all subpages. Additionally, we need data on user journeys, such as heat mapping or session journeys.

## Approach
Eval the Matomo platform, which includes user journey features. Additionally, evaluate how the platforms track bounces and time on pages.

## Learning
We are evaluating analytics platforms that comply with EU restrictions on data collection. We tried Plausible and Umami. An interesting thing with those platforms is how they track user interactions on the page, which results in resolved and recorded high bounce rates, which skews the data.

##Options
If none of the platforms are accurate, we may need to use Google Analytics and try to make it EU-compatible or install a cookie disclaimer.