### PR TITLE
Fix paragraph responsiveness

### DIFF
--- a/routes/blog-post-route.tsx
+++ b/routes/blog-post-route.tsx
@@ -34,7 +34,7 @@ export function blogPostRoute(): JSXHandler {
 
     return (
       <AppHtml>
-        <article class="flex flex-col items-center p-6 lg:p-0 text-blue-primary">
+        <article class="flex flex-col items-center mx-auto p-6 lg:p-0 text-blue-primary">
           <header class="flex flex-col justify-center items-center mb-8 max-w-3xl">
             <section class="p-4 md:p-0">
               <h1 class="mb-4 max-w-prose font-black text-2xl md:text-4xl uppercase">
@@ -61,7 +61,7 @@ export function blogPostRoute(): JSXHandler {
               height={300}
             />
           </header>
-          <section class="mx-auto text-blue-primary lg:prose-lg prose">
+          <section class="mx-auto w-full sm:max-w-screen-sm text-blue-primary lg:prose-lg prose">
             <link rel="stylesheet" href="/assets/prism-atom-one-dark.css" />
             <post.content />
           </section>


### PR DESCRIPTION


## Motivation

Paragraphs were pushing over the edge of the viewport on mobile.

## Approach

Make paragraph flow with the change of viewport

## Screenshots

**BEFORE:::**

<img width="300" height="16384" alt="frontside com_blog_2025-08-04-the-heartbreaking-inadequacy-of-abort-controller_(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/e0ea69d8-0e0e-46d3-8c03-48ac40931a07" />

**AFTER:::**

**Safari Mobile Simulator Screenshot**
<img width="350" height="2556" alt="simulator_screenshot_52269468-3B56-4F06-949A-3F6C5ED6B115" src="https://github.com/user-attachments/assets/c889ac3f-179d-43ce-b5f5-a23114c5fff4" />


**Responsive Screen Shot**
<img width="200" height="20000" alt="localhost_8005_blog_2025-08-04-the-heartbreaking-inadequacy-of-abort-controller_(iPhone SE)" src="https://github.com/user-attachments/assets/64062bed-6ba2-41b4-834a-b36bb9355bfa" />

