### PR TITLE
✨Expose proxied sites to search engines

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -20,6 +20,7 @@
   "imports": {
     "effection": "jsr:@effection/effection@3.2.0",
     "hast": "npm:hast@^1.0.0",
+    "hast-util-select": "npm:hast-util-select",
     "revolution": "https://deno.land/x/revolution@0.6.1/mod.ts",
     "revolution/jsx-runtime": "https://deno.land/x/revolution@0.6.1/jsx-runtime.ts"
   }

--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,5 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
     "jsr:@effection/effection@3.2.0": "3.2.0",
     "jsr:@frontside/continuation@0.1.6": "0.1.6",
@@ -215,10 +215,12 @@
       ]
     },
     "acorn@8.14.0": {
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "bin": true
     },
     "astring@1.9.0": {
-      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "bin": true
     },
     "bail@2.0.2": {
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
@@ -278,7 +280,8 @@
       ]
     },
     "direction@2.0.1": {
-      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "bin": true
     },
     "entities@4.5.0": {
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
@@ -561,7 +564,8 @@
       ]
     },
     "hast@1.0.0": {
-      "integrity": "sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA=="
+      "integrity": "sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==",
+      "deprecated": true
     },
     "hastscript@7.2.0": {
       "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
@@ -1518,7 +1522,8 @@
       "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
     },
     "yaml@2.6.1": {
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg=="
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "bin": true
     },
     "zwitch@2.0.4": {
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
@@ -1843,6 +1848,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@effection/effection@3.2.0",
+      "npm:hast-util-select@*",
       "npm:hast@1"
     ]
   }

--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -2,7 +2,7 @@ import type { HTTPMiddleware } from "revolution";
 import { call, Operation } from "effection";
 import { fromHtml } from "npm:hast-util-from-html";
 import { toHtml } from "npm:hast-util-to-html";
-import { selectAll } from "npm:hast-util-select";
+import { select, selectAll } from "hast-util-select";
 import { posixNormalize } from "https://deno.land/std@0.201.0/path/_normalize.ts";
 import { injectPlausible } from "../plugins/plausible.ts";
 import { injectUmami } from "../plugins/umami.ts";
@@ -66,6 +66,17 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
       yield* injectPlausible(tree);
       yield* injectUmami(tree);
       yield* injectMatomo(tree);
+
+      // allow proxied site to be indexable
+      let head = select("head", tree);
+
+      if (head) {
+        head.children = head.children.filter((el) =>
+          !(el.type === "element" && el.tagName === "meta" &&
+            el.properties.name === "robots" &&
+            el.properties.content === "noindex")
+        );
+      }
 
       let elements = selectAll(
         '[href^="/"],[src^="/"],form[action],[http-equiv="refresh"][content]',


### PR DESCRIPTION
## Motivation

One of the problems we have is that the proxied site is a website in of itself. It is nice to be able to treat these sites as separate entities when doing development and code reviews. For example, a PR review on the effection website (which is stored inside the effection repository) would create a url when developers can inspect what the finished product would look like: e.g.
https://effection-upgrade-tailwind.deno.dev

However, we do not want Google, Bing, and friends crawling these websites and indexing them. This is not a theoretical concern. In fact, this is what happened to us recently when somehow the top google search result for "Effection JavasScript" yields to `https://effection-www.deno.dev` as its first result.


## Approach
The solution is to mark the page with a "robots" meta tag https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots that indicates that crawlers should ignore the site. This will prevent it from showing up in search results.

Then, inside this production website (frontside.com), we remove that tag so that the page itself can, in fact, be indexed and `https://frontside.com/effection` will be the authoritative resource.
