### PR TITLE
fix proxying meta content

### DIFF
--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -68,7 +68,7 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
       yield* injectMatomo(tree);
 
       let elements = selectAll(
-        '[href^="/"],[src^="/"],form[action],[http-equiv="refresh"][content]',
+        '[href^="/"],[src^="/"],form[action],meta[content]',
         tree,
       );
 
@@ -97,6 +97,8 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
                 url,
                 posixNormalize(`${base.pathname}${url}`),
               );
+            } else if (properties.content.startsWith("http")) {
+              properties.content = properties.content.replace(target.href, base.href.replace(/\/?$/,'/'));
             }
           }
         }


### PR DESCRIPTION
## Motivation
Our meta content tags are not being replaced by the base url.

## Approach
This replaces them with the base of the current url when they are encounterd in the same way we do with href, src, etc...
