### PR TITLE
feat: add /llms.txt route for AI agent discovery

### DIFF
--- a/assets/llms.txt
+++ b/assets/llms.txt
@@ -1,0 +1,34 @@
+# Frontside
+
+> Frontside is a software consultancy specializing in Developer Experience (DX),
+> internal developer platforms, and open source tools for JavaScript.
+
+Frontside helps engineering teams build better developer experiences, from local
+development environments to production deployment pipelines. We specialize in
+Backstage implementation, testing strategy, and structured concurrency.
+
+## Services
+
+- [DX Consulting](https://frontside.com/dx-consulting): Developer experience consulting for Cloud native teams
+- [Backstage Implementation](https://frontside.com/backstage): Internal developer portal expertise and plugin development
+
+## Open Source Projects
+
+- [Effection](https://frontside.com/effection/llms.txt): Structured concurrency for JavaScript - see detailed llms.txt for API docs and extension packages
+- [Interactors](https://frontside.com/interactors): Page objects for component library testing
+- [GraphGen](https://frontside.com/graphgen): Generate realistic graph data for testing
+
+## Blog
+
+Technical articles on DX, testing, Backstage, and JavaScript. Notable posts:
+
+- [Announcing Effection 4.0](https://frontside.com/blog/2025-12-23-announcing-effection-v4): Major release with improved determinism
+- [The Heartbreaking Inadequacy of AbortController](https://frontside.com/blog/2025-08-04-the-heartbreaking-inadequacy-of-abort-controller): Why JavaScript needs structured concurrency
+- [Effection: When async/await is not enough](https://frontside.com/blog/2021-10-26-effection-async-await): Introduction to structured concurrency
+
+## Optional
+
+- [All blog posts](https://frontside.com/blog)
+- [About Frontside](https://frontside.com/about)
+- [Contact](https://frontside.com/contact)
+- [Case Study: Resideo](https://frontside.com/work/case-studies/resideo)

--- a/deno.json
+++ b/deno.json
@@ -18,7 +18,8 @@
     "jsxImportSource": "revolution"
   },
   "imports": {
-    "effection": "jsr:@effection/effection@3.2.0",
+    "effection": "jsr:@effection/effection@3.6.1",
+    "@effectionx/fs": "npm:@effectionx/fs",
     "hast": "npm:hast@^1.0.0",
     "revolution": "https://deno.land/x/revolution@0.6.1/mod.ts",
     "revolution/jsx-runtime": "https://deno.land/x/revolution@0.6.1/jsx-runtime.ts"

--- a/main.tsx
+++ b/main.tsx
@@ -10,6 +10,7 @@ import { backstageServicesRoute } from "./routes/backstage.html.tsx";
 import { dxConsultingServicesRoute } from "./routes/dx-consulting.html.tsx";
 import { pluginWorkshopRoute } from "./routes/advanced-backstage-plugin-development-route.tsx";
 import { resideoBackstageCaseStudyRoute } from "./routes/work/case-studies/case-study-resideo.html.tsx";
+import { llmsTxtRoute } from "./routes/llms-txt-route.ts";
 
 import { etagPlugin } from "./plugins/etag.ts";
 import { currentRequestPlugin } from "./plugins/current-request.ts";
@@ -31,6 +32,7 @@ await main(function* (args) {
 
   let revolution = createRevolution({
     app: [
+      route("/llms.txt", llmsTxtRoute()),
       route("/", indexRoute()),
       route("/blog", blogIndexRoute()),
       route("/blog/:id", blogPostRoute()),

--- a/routes/llms-txt-route.ts
+++ b/routes/llms-txt-route.ts
@@ -1,0 +1,22 @@
+import type { HTTPMiddleware } from "revolution";
+import { call } from "effection";
+
+/**
+ * Serves the /llms.txt file for AI agent discovery.
+ *
+ * This follows the llms.txt standard (https://llmstxt.org/) to help
+ * AI agents understand and navigate Frontside's content and projects.
+ */
+export function llmsTxtRoute(): HTTPMiddleware {
+  return function* () {
+    const content = yield* call(() =>
+      Deno.readTextFile(new URL("../assets/llms.txt", import.meta.url))
+    );
+    return new Response(content, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+  };
+}


### PR DESCRIPTION
# Motivation

Position Frontside content to be found and recommended by AI tools like Claude, ChatGPT, and Copilot. The [llms.txt standard](https://llmstxt.org/) provides a structured way for AI agents to discover and understand a site's content, similar to how robots.txt works for search engines.

# Approach

- Add a `/llms.txt` route that returns plain text describing Frontside's services, open source projects (Effection, Interactors, GraphGen), and notable blog posts
- Wire the route in `main.tsx` before the legacy proxy catch-all so it gets matched
- Add `AGENTS.md` documenting the implementation plan and follow-up tasks (Effection repo enhancements, directory registration)