### PR TITLE
fix: use absolute paths for blog thumbnail images

### DIFF
--- a/routes/blog-index-route.tsx
+++ b/routes/blog-index-route.tsx
@@ -30,7 +30,7 @@ export function blogIndexRoute() {
               <img
                 class="flex-shrink-0 mr-8 rounded-lg w-[100%] max-w-[500px] h-auto"
                 src={latest.image
-                  ? `blog/${latest.id}/${latest.image}`
+                  ? `/blog/${latest.id}/${latest.image}`
                   : "/assets/fs-logo-no-text.svg"}
                 alt="blog image"
               />
@@ -61,7 +61,7 @@ export function blogIndexRoute() {
                     <img
                       class="box-content flex-shrink-0 rounded-lg w-full h-[250px] overflow-clip object-contain"
                       src={post.image
-                        ? `blog/${post.id}/${post.image}`
+                        ? `/blog/${post.id}/${post.image}`
                         : "/assets/fs-logo-no-text.svg"}
                       alt="blog image"
                     />


### PR DESCRIPTION
# Motivation

Blog thumbnails on https://frontside.com/blog/ are broken. The images fail to load because the src paths are relative (`blog/...`) which resolve incorrectly when on the `/blog/` page, becoming `/blog/blog/...` (double `blog/`).

# Approach

Changed image src paths from relative to absolute by adding a leading slash:
- `blog/${post.id}/${post.image}` → `/blog/${post.id}/${post.image}`

This matches the pattern already used in `blog-tag-route.tsx`.