### PR TITLE
Fix og:image URL rewriting in proxy route

### DIFF
--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -101,7 +101,7 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
                 posixNormalize(`${base.pathname}${url}`),
               );
             } else if (properties.content.startsWith("http")) {
-              properties.content = properties.content.replace(target.href, base.href.replace(/\/?$/,'/'));
+              properties.content = properties.content.replace(target.origin, base.href.replace(/\/?$/, ''));
             }
           }
         }


### PR DESCRIPTION
## Motivation

Blog post og:image URLs were being mangled during proxy rewriting, causing
staticalization to crash with 404 errors. For example, an upstream og:image at
`https://effection.deno.dev/blog/<post>/meta-effection.png?w=2400&h=1260` was
being rewritten to `http://localhost:8005/effection/meta-effection.png?w=2400&h=1260`,
losing the `blog/<post>/` path segment entirely.

## Approach

Replace `target.origin` instead of `target.href` when rewriting meta content
attributes in the proxy route. Using `target.href` replaced the full page URL
(including path) with the base prefix, which collapsed intermediate path
segments. Using `target.origin` replaces only the scheme+host+port, preserving
the full resource path.