### PR TITLE
Remove interactors proxy root rewriting

### DIFF
--- a/main.tsx
+++ b/main.tsx
@@ -131,7 +131,6 @@ function proxySites() {
     },
     interactors: {
       prefix: "interactors",
-      root: "interactors/",
       website: Deno.env.get("INTERACTORS_URL") ??
         "https://interactors.deno.dev",
     },


### PR DESCRIPTION
## Summary
- Remove the `root: "interactors/"` config from the interactors proxy site
- No longer needed since thefrontside/interactors#319 replaced Docusaurus, which had the base URL baked into its client-side JS and required root rewriting to compensate

## Test plan
- [ ] Verify interactors site loads correctly at `/interactors` with no broken assets or routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)