### PR TITLE
🐛 stop proxy from serving decompressed HTML as gzip

### DIFF
--- a/routes/proxy-route.ts
+++ b/routes/proxy-route.ts
@@ -18,7 +18,9 @@ export interface ProxyRouteOptions {
 }
 
 export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
-  let middleware: HTTPMiddleware & SitemapExtension = function* proxy(request): Operation<Response> {
+  let middleware: HTTPMiddleware & SitemapExtension = function* proxy(
+    request,
+  ): Operation<Response> {
     let website = new URL(options.website);
 
     let target = new URL(request.url);
@@ -41,10 +43,7 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
     if ([301, 302, 307, 308].includes(response.status)) {
       let location = response.headers.get("location");
       if (location?.startsWith(String(website))) {
-        let headers: Record<string, string> = {};
-        for (let [key, value] of response.headers.entries()) {
-          headers[key] = value;
-        }
+        let headers = copyHeaders(response);
 
         let url = new URL(request.url);
 
@@ -101,20 +100,18 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
                 posixNormalize(`${base.pathname}${url}`),
               );
             } else if (properties.content.startsWith("http")) {
-              properties.content = properties.content.replace(target.origin, base.href.replace(/\/?$/, ''));
+              properties.content = properties.content.replace(
+                target.origin,
+                base.href.replace(/\/?$/, ""),
+              );
             }
           }
         }
       }
-      let headers: Record<string, string> = {};
-      for (let [key, value] of response.headers.entries()) {
-        headers[key] = value;
-      }
-
       response = new Response(toHtml(tree), {
         status: response.status,
         statusText: response.statusText,
-        headers,
+        headers: copyHeaders(response),
       });
     }
 
@@ -123,7 +120,10 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
 
   if (options.prefix) {
     middleware.sitemapExtension = function* (): Operation<RoutePath[]> {
-      let sitemap = new URL(`/${options.root ?? ""}sitemap.xml`, options.website);
+      let sitemap = new URL(
+        `/${options.root ?? ""}sitemap.xml`,
+        options.website,
+      );
       try {
         let response = yield* call(() => fetch(sitemap));
         if (!response.ok) return [];
@@ -148,6 +148,28 @@ export function proxyRoute(options: ProxyRouteOptions): HTTPMiddleware {
   return middleware;
 }
 
+// Copy an upstream response's headers, dropping the ones that describe how the
+// *original* body was framed on the wire. `fetch()` transparently decompresses
+// the body, so by the time we rebuild the response the payload is plain text —
+// carrying over the upstream `content-encoding` (e.g. gzip) or its stale
+// `content-length` makes us serve uncompressed bytes labelled as gzip, which
+// downstream clients then fail to decode ("Invalid gzip header"). Let the
+// server recompute these for the new body.
+function copyHeaders(response: Response): Record<string, string> {
+  let skip = new Set([
+    "content-encoding",
+    "content-length",
+    "transfer-encoding",
+  ]);
+  let headers: Record<string, string> = {};
+  for (let [key, value] of response.headers.entries()) {
+    if (!skip.has(key.toLowerCase())) {
+      headers[key] = value;
+    }
+  }
+  return headers;
+}
+
 function parseSitemapUrls(
   xml: string,
   options: ProxyRouteOptions,
@@ -159,7 +181,9 @@ function parseSitemapUrls(
     let loc = match[1];
     try {
       let url = new URL(loc);
-      let path = options.root ? url.pathname.replace(`/${options.root}`, "/") : url.pathname;
+      let path = options.root
+        ? url.pathname.replace(`/${options.root}`, "/")
+        : url.pathname;
       let pathname = posixNormalize(`/${options.prefix}${path}`);
       paths.push({ pathname });
     } catch {


### PR DESCRIPTION
## Motivation

The `deploy` workflow was failing at the Staticalize step with an uncaught `TypeError: Invalid gzip header`. Running the (newly improved) staticalize against the live local site pinpointed it: **259 pages OK, but 349 failures — every one `Invalid gzip header`, all confined to the proxied doc sub-sites** `/effection/*`, `/interactors/*`, `/graphgen/*`.

Root cause is in `routes/proxy-route.ts`. For HTML responses the proxy reads the upstream body with `response.text()` — which `fetch()` has already **decompressed** — rewrites the HTML, and rebuilds the `Response` from the plain-text result. But it copied the upstream headers verbatim onto the new body, including `content-encoding: gzip` and the stale `content-length`. So it served **uncompressed HTML labelled as gzip**, and any client (staticalize, browsers) failed to decode it.

Assets went through the untouched `return response` pass-through, which Deno serves correctly — which is why only the rewritten HTML pages broke.

## Approach

Add a `copyHeaders()` helper that copies an upstream response's headers while dropping the ones that describe the *original* wire framing — `content-encoding`, `content-length`, `transfer-encoding` — and let the server recompute them for the rebuilt body. Applied in both the HTML-rewrite branch and the redirect branch.

## Verification

Ran the site locally with the fix and re-ran staticalize exactly as CI does:

- **Before:** `259 pages, 349 errors`, exit 1
- **After:** `608 pages, 322 assets, 0 errors`, exit 0

`/effection/` now responds without `content-encoding: gzip` and with a correct `content-length`, and the body decodes as HTML.

The staticalize error-reporting improvement ([staticalize#8](https://github.com/thefrontside/staticalize/pull/8)) is what surfaced the offending URLs but is not required for this fix.