### PR TITLE
dependabot only looks at gha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/legacy" # Location of package manifests
+  # The main site uses Deno, which Dependabot does not natively support.
+  # Legacy dependencies are ignored — that site is frozen.
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Motivation

We don't want updates on the legacy folder. Repoint the config instead at just generically updating our GitHub Actions thereby not handling the legacy folder.
