### PR TITLE
🐛 Rebuild Effection search index during deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -61,6 +61,15 @@ jobs:
           --concurrency=25 \
           --retries=5
 
+    - name: Build Effection Search Index
+      run: |
+        npx --yes pagefind@1.3.0 \
+          --site built/effection \
+          --output-path built/effection/pagefind
+
+        test -s built/effection/pagefind/pagefind.js
+        test -s built/effection/pagefind/pagefind-entry.json
+
     - name: Deploy Preview to Netlify
       id: netlify
       run: |
@@ -145,6 +154,15 @@ jobs:
             --base=https://frontside.com \
             --concurrency=25 \
             --retries=5
+
+      - name: Build Effection Search Index
+        run: |
+          npx --yes pagefind@1.3.0 \
+            --site built/effection \
+            --output-path built/effection/pagefind
+
+          test -s built/effection/pagefind/pagefind.js
+          test -s built/effection/pagefind/pagefind-entry.json
 
       - name: Deploy to Production
         run: |


### PR DESCRIPTION
# Motivation

The Effection search page loads its Pagefind UI script from the staticalized site, but the dynamically imported Pagefind runtime, manifest, index, and WASM assets are absent. Staticalize copies assets referenced directly by HTML and does not follow the JavaScript import graph, so `/effection/pagefind/pagefind.js` and `/effection/pagefind/pagefind-entry.json` return 404 in production.

# Approach

- Run the pinned Pagefind CLI after Staticalize in both preview and production jobs.
- Index `built/effection` and write the complete bundle to `built/effection/pagefind`.
- Assert that the Pagefind runtime and entry manifest exist before deployment.

Validated with YAML parsing, a pinned Pagefind 1.3.0 fixture build, and a browser search confirming that assets load from `/effection/pagefind/` and results resolve to `/effection/docs/`.