### PR TITLE
♻️ Use Effection's published Pagefind bundle

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -61,15 +61,6 @@ jobs:
           --concurrency=25 \
           --retries=5
 
-    - name: Build Effection Search Index
-      run: |
-        npx --yes pagefind@1.3.0 \
-          --site built/effection \
-          --output-path built/effection/pagefind
-
-        test -s built/effection/pagefind/pagefind.js
-        test -s built/effection/pagefind/pagefind-entry.json
-
     - name: Deploy Preview to Netlify
       id: netlify
       run: |
@@ -154,15 +145,6 @@ jobs:
             --base=https://frontside.com \
             --concurrency=25 \
             --retries=5
-
-      - name: Build Effection Search Index
-        run: |
-          npx --yes pagefind@1.3.0 \
-            --site built/effection \
-            --output-path built/effection/pagefind
-
-          test -s built/effection/pagefind/pagefind.js
-          test -s built/effection/pagefind/pagefind-entry.json
 
       - name: Deploy to Production
         run: |


### PR DESCRIPTION
> Depends on thefrontside/effection#1219. Do not merge this PR until that change has been merged and deployed to `effection.netlify.app`.

# Motivation

Frontside currently rebuilds Effection’s Pagefind index after Staticalize because the upstream site does not expose dynamically loaded search assets to the crawler. This duplicates Effection’s indexing work, pins a second Pagefind version, and makes the composition build responsible for an implementation detail of the mounted site.

Thefrontside/effection#1219 publishes the complete Pagefind bundle through Effection’s sitemap and makes its result URLs mount-aware.

# Approach

Remove the preview and production Pagefind reindexing steps. Once the upstream PR is deployed, the existing Staticalize step will discover and copy Effection’s Pagefind asset index as part of the normal sitemap crawl.

Validated by parsing `.github/workflows/deploy.yaml` and running `git diff --check`. The workflow has existing formatting drift outside this change, so it was intentionally not reformatted.