### PR TITLE
🔥 Drop the Effection search index CI step

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -61,15 +61,6 @@ jobs:
           --concurrency=25 \
           --retries=5
 
-    - name: Build Effection Search Index
-      run: |
-        npx --yes pagefind@1.3.0 \
-          --site built/effection \
-          --output-path built/effection/pagefind
-
-        test -s built/effection/pagefind/pagefind.js
-        test -s built/effection/pagefind/pagefind-entry.json
-
     - name: Deploy Preview to Netlify
       id: netlify
       run: |
@@ -154,15 +145,6 @@ jobs:
             --base=https://frontside.com \
             --concurrency=25 \
             --retries=5
-
-      - name: Build Effection Search Index
-        run: |
-          npx --yes pagefind@1.3.0 \
-            --site built/effection \
-            --output-path built/effection/pagefind
-
-          test -s built/effection/pagefind/pagefind.js
-          test -s built/effection/pagefind/pagefind-entry.json
 
       - name: Deploy to Production
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,6 @@ permissions:
   contents: read
 
 jobs:
-  # --- PULL REQUEST PREVIEW DEPLOYMENT ---
   deploy-preview:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Motivation

The `Build Effection Search Index` step (added in #498) runs `npx pagefind --site built/effection` at deploy time to work around the fact that Staticalize couldn't capture Effection's dynamically-loaded Pagefind bundle.

The Effection docs site now advertises every file in its Pagefind bundle through its own `sitemap.xml` (thefrontside/effection#1220). The proxy already re-prefixes those sitemap entries under `/effection`, so Staticalize captures the bundle in its normal crawl — the CI step is redundant.

# Approach

Remove the `Build Effection Search Index` step from both the preview and production jobs. No proxy or sitemap change is needed.

# Sequencing

**Draft until thefrontside/effection#1220 deploys to `effection.netlify.app`.** Merging this before Effection advertises its bundle would ship `/effection` search with a missing index. Once Effection is live (its sitemap lists `/pagefind/*`), this is safe to merge.